### PR TITLE
offset should be set to 0 if this attribute is missed in stop tag

### DIFF
--- a/batik-bridge/src/main/java/org/apache/batik/bridge/AbstractSVGGradientElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/AbstractSVGGradientElementBridge.java
@@ -313,9 +313,8 @@ public abstract class AbstractSVGGradientElementBridge
 
             String s = stopElement.getAttributeNS(null, SVG_OFFSET_ATTRIBUTE);
             if (s.length() == 0) {
-                throw new BridgeException
-                    (ctx, stopElement, ERR_ATTRIBUTE_MISSING,
-                     new Object[] {SVG_OFFSET_ATTRIBUTE});
+                //use default value according to the specification
+                s = "0";
             }
             float offset;
             try {


### PR DESCRIPTION
Many modern design tools like Figma and others do not put `offset` attribute when generating a svg image if offset equals `0`. See https://www.w3.org/TR/SVG/pservers.html#GradientStopAttributes 

Batik fails with exception while trying to read such svgs. Other programs successfully open these files. 
The pull request sets `offset` to `0` when the attribute is missing.
Example of an icon:
```
<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
<path d="M5.80005 22.2L1.30005 18.7L3.90005 13.9L7.80005 15.2L5.80005 22.2Z" fill="url(#paint0_linear)"/>
<path d="M31 9L30.5 26.4L18.9 31L12.6 26.9L31 9Z" fill="#087CFA"/>
<path d="M31 9L24.9 15L17.8 5.7L21.6 1.5L31 9Z" fill="url(#paint1_linear)"/>
<path d="M12.6 26.9L3.4 30.3L5.3 23.5L7.8 15.2L1 12.9L5.3 1L15.2 2.2L24.5 14L24.8 15L12.6 26.9Z" fill="url(#paint2_linear)"/>
<path d="M25 7H7V25H25V7Z" fill="url(#paint3_linear)"/>
<path d="M15.7 21.9H9V23H15.7V21.9Z" fill="white"/>
<path d="M12.63 10.49V9.25H9.26001V10.49H10.2V14.76H9.26001V15.99H12.63V14.76H11.68V10.49H12.63Z" fill="white"/>
<path d="M15.87 16.09C15.34 16.09 14.9 15.99 14.55 15.79C14.19 15.59 13.9 15.35 13.67 15.08L14.6 14.04C14.79 14.25 14.99 14.42 15.18 14.54C15.38 14.66 15.59 14.72 15.83 14.72C16.11 14.72 16.33 14.63 16.49 14.45C16.65 14.27 16.73 13.99 16.73 13.6V9.26001H18.25V13.67C18.25 14.07 18.2 14.42 18.09 14.72C17.98 15.02 17.82 15.27 17.62 15.47C17.41 15.68 17.16 15.83 16.86 15.94C16.56 16.04 16.23 16.09 15.87 16.09Z" fill="white"/>
<defs>
<linearGradient id="paint0_linear" x1="3.21765" y1="18.0954" x2="18.1487" y2="17.3385" gradientUnits="userSpaceOnUse">
<stop offset="0.0910927" stop-color="#FC801D"/>
<stop offset="0.2312" stop-color="#B07F61"/>
<stop offset="0.4086" stop-color="#577DB3"/>
<stop offset="0.5334" stop-color="#1E7CE6"/>
<stop offset="0.5934" stop-color="#087CFA"/>
</linearGradient>
<linearGradient id="paint1_linear" x1="27.5676" y1="16.8208" x2="22.4964" y2="1.6674" gradientUnits="userSpaceOnUse">
<stop stop-color="#FE2857"/>
<stop offset="0.0784" stop-color="#CB3979"/>
<stop offset="0.1601" stop-color="#9E4997"/>
<stop offset="0.2474" stop-color="#7557B2"/>
<stop offset="0.3392" stop-color="#5362C8"/>
<stop offset="0.4365" stop-color="#386CDA"/>
<stop offset="0.5414" stop-color="#2373E8"/>
<stop offset="0.6576" stop-color="#1478F2"/>
<stop offset="0.794" stop-color="#0B7BF8"/>
<stop offset="1" stop-color="#087CFA"/>
</linearGradient>
<linearGradient id="paint2_linear" x1="5.3142" y1="8.0695" x2="24.0899" y2="39.1256" gradientUnits="userSpaceOnUse">
<stop stop-color="#FE2857"/>
<stop offset="0.0800816" stop-color="#FE295F"/>
<stop offset="0.2065" stop-color="#FF2D76"/>
<stop offset="0.3034" stop-color="#FF318C"/>
<stop offset="0.3846" stop-color="#EA3896"/>
<stop offset="0.5532" stop-color="#B248AE"/>
<stop offset="0.7923" stop-color="#5A63D6"/>
<stop offset="1" stop-color="#087CFA"/>
</linearGradient>
<linearGradient id="paint3_linear" x1="15.976" y1="2.6251" x2="15.976" y2="18.7675" gradientUnits="userSpaceOnUse">
<stop offset="0.0842986" stop-color="#878585"/>
<stop offset="0.5377"/>
</linearGradient>
</defs>
</svg> 
```