### PR TITLE
Support SVG files with version 1 as well as 1.0

### DIFF
--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SAXSVGDocumentFactory.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SAXSVGDocumentFactory.java
@@ -319,7 +319,7 @@ public class SAXSVGDocumentFactory
 
     public DOMImplementation getDOMImplementation(String ver) {
         if (ver == null || ver.length() == 0
-                || ver.equals("1.0") || ver.equals("1.1")) {
+                || ver.equals("1.0") || ver.equals("1.1") || ver.equals("1")) {
             return SVGDOMImplementation.getDOMImplementation();
         } else if (ver.equals("1.2")) {
             return SVG12DOMImplementation.getDOMImplementation();


### PR DESCRIPTION
Currently, if you attempt to parse a SVG file whose version is set as "1" instead of "1.0", the results is a RuntimeException: "Unsupport SVG version '1'". Yes, I know SVG versions without the decimal point are nonstandard. However, that does not mean that they are not used. Most SVG parsers accept "1" as a substitute for "1.0" with no issue, but Batik does not. Many examples of SVG files that use version "1" instead of "1.0" can be found at: https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/tree/master/Papirus/64x64/places