### PR TITLE
BATIK-1296: AbstractDocument.importNode(Node, boolean) does not set the attributes of elements

### DIFF
--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
@@ -365,6 +365,8 @@ public abstract class AbstractDocument
         case ATTRIBUTE_NODE:
             result = createAttributeNS(importedNode.getNamespaceURI(),
                                        importedNode.getNodeName());
+            result.setNodeValue(importedNode.getNodeValue());
+            deep = false;
             break;
 
         case TEXT_NODE:


### PR DESCRIPTION
When a document is imported, the attributes of its elements are imported without their values being set, and this PR fixes the problem.