### PR TITLE
bz-44682: TranscoderException and EnclosedException when transcoding SVG to JPEG

### DIFF
--- a/batik-transcoder/pom.xml
+++ b/batik-transcoder/pom.xml
@@ -52,6 +52,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-codec</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-dom</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
There is an old issue in bugzilla (which I hit too):

https://bz.apache.org/bugzilla/show_bug.cgi?id=44682

caused by the `batik-transcoder` POM file failing to include the `batik-codec` dependency. Adding it fixes the problem.

Similar issue in JIRA: BATIK-1188.