### PR TITLE
BATIK-1289: batik, xml-apis(-ext) and java modules

### DIFF
--- a/batik-dom/pom.xml
+++ b/batik-dom/pom.xml
@@ -67,11 +67,6 @@
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <version>${xmlapis.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>xml-apis</groupId>
       <artifactId>xml-apis-ext</artifactId>
       <version>${xmlapisext.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <rhino.version>1.7.7</rhino.version>
     <surefire.version>2.18.1</surefire.version>
     <xalan.version>2.7.2</xalan.version>
-    <xmlapis.version>1.4.01</xmlapis.version>
     <xmlapisext.version>1.3.04</xmlapisext.version>
     <xmlgraphics.commons.version>2.4.0-SNAPSHOT</xmlgraphics.commons.version>
     <jdk.path>${env.JAVA_HOME}</jdk.path>


### PR DESCRIPTION
Remove dependency on xml-apis. The dependency is transitive, and it is causing errors in downstream projects, for example:

`[ERROR] the unnamed module reads package org.w3c.dom.css from both xml.apis and jdk.xml.dom`