### PR TITLE
shutdown() function for CleanerThread

### DIFF
--- a/batik-util/src/main/java/org/apache/batik/util/HaltingThread.java
+++ b/batik-util/src/main/java/org/apache/batik/util/HaltingThread.java
@@ -31,7 +31,7 @@ public class HaltingThread extends Thread {
     /**
      * Boolean indicating if this thread has ever been 'halted'.
      */
-    protected boolean beenHalted = false;
+    protected volatile boolean beenHalted = false;
 
     public HaltingThread() { }
 


### PR DESCRIPTION
proper fix for:

https://issues.apache.org/jira/browse/BATIK-939

instead of using or suppressing interrupts, a simple CountDownLatch is used to check whether the thread should shut down or not.