### PR TITLE
Fixing SVG to PNG Rendering due to missing Arabic Characters from the…

### DIFF
--- a/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
@@ -620,6 +620,12 @@ public final class ArabicTextHandler {
 
         null,                                          // 0x0628
         null,                                          // 0x0629
+        null,                                          // 0x062A
+        null,                                          // 0x062B
+        null,                                          // 0x062C
+        null,                                          // 0x062D
+        null,                                          // 0x062E
+        null,                                          // 0x062F
         null,                                          // 0x0630
         null,                                          // 0x0631
         null,                                          // 0x0632


### PR DESCRIPTION
Upon checking the list of Arabic characters [here](https://asecuritysite.com/coding/asc2?val=1536%2C1792) the supported character according to ArabicTextHandler are from 0x622 to 0x652. The total number of characters between hex 0x622 to 0x652 according to the website there are 49 characters in total for which mapping should be present, but currently there are only 43 entries in doubleCharRemappings array in /batik/gvt/text/ArabicTextHandler.java file

These 6 characters are missing from the map 

| ت | 1578 | 0000011000101010 | 62a | 3052 | &#1578; |
| - | ---- | ---------------- | --- | ---- | ------- |
| ث | 1579 | 0000011000101011 | 62b | 3053 | &#1579; |
| ج | 1580 | 0000011000101100 | 62c | 3054 | &#1580; |
| ح | 1581 | 0000011000101101 | 62d | 3055 | &#1581; |
| خ | 1582 | 0000011000101110 | 62e | 3056 | &#1582; |
| د | 1583 | 0000011000101111 | 62f | 3057 | &#1583; |
