### PR TITLE
Fixing SVG to PNG Transcoding Error due to missing Arabic Characters …

### DIFF
--- a/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
@@ -620,6 +620,12 @@ public final class ArabicTextHandler {
 
         null,                                          // 0x0628
         null,                                          // 0x0629
+        null,                                          // 0x062A
+        null,                                          // 0x062B
+        null,                                          // 0x062C
+        null,                                          // 0x062D
+        null,                                          // 0x062E
+        null,                                          // 0x062F
         null,                                          // 0x0630
         null,                                          // 0x0631
         null,                                          // 0x0632

--- a/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
@@ -276,6 +276,17 @@ public class SVGConverterTest extends DefaultTestSuite {
         addTest(t);
         t.setId("Operationtest.PDFTranscoding");
 
+        // Test for SVG to PNG Transcoding for Arabic Characters
+        t = new OperationTest(){
+            protected  void configure(SVGConverter c){
+                c.setDestinationType(DestinationType.PNG);
+                c.setSources(new String[]{"samples/tests/spec/text/arabicCharacters.svg"});
+                c.setDst(new File("samples/arabicCharacters.png"));
+            }
+        };
+        addTest(t);
+        t.setId("OperationTest.Bug_BATIK1355");
+
         ///////////////////////////////////////////////////////////////////////
         // Add configuration error test. These tests check that the expected
         // error gets reported for a given mis-configuration

--- a/batik-test-old/src/test/java/org/apache/batik/test/xml/JUnitRunnerTestCase.java
+++ b/batik-test-old/src/test/java/org/apache/batik/test/xml/JUnitRunnerTestCase.java
@@ -228,6 +228,7 @@ public class JUnitRunnerTestCase {
 "transcoder.image.hints.px2mm.96dpi",
 "transcoder.image.hints.px2mm.72dpi",
 "samples/anne.svg",
+"samples/arabicCharacters.svg",
 "samples/asf-logo.svg",
 "samples/barChart.svg",
 "samples/batik3D.svg",

--- a/build.xml
+++ b/build.xml
@@ -1059,6 +1059,7 @@ JAVA=/usr/bin/java
     <delete file="${samples}/tests/spec/scripting/java-binding.jar"/>
     <delete file="${samples}/anne.pdf"/>
     <delete file="${samples}/anne.png"/>
+    <delete file="${samples}/arabicCharacters.png"/>
     <delete dir="${test-references}" includes="**/candidate-reference/**" includeemptydirs="true"/>
     <delete dir="${test-references}" includes="**/candidate-reference" includeemptydirs="true"/>
     <delete dir="${test-references}" includes="**/candidate-variation/**" includeemptydirs="true"/>

--- a/samples/tests/spec/text/arabicCharacters.svg
+++ b/samples/tests/spec/text/arabicCharacters.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="700" height="500" viewBox="0 0 700 500">
+	<g font-family="dialog" font-size="35" text-anchor="start">
+		<text fill="DarkRed" x="5%" y="10%"
+		> Arabic Shadda : شارع طَوِي أم الظِّبا </text>
+	</g>
+</svg>


### PR DESCRIPTION
Upon checking the list of Arabic characters [here](https://asecuritysite.com/coding/asc2?val=1536%2C1792) the supported character according to ArabicTextHandler are from 0x622 to 0x652. The total number of characters between hex 0x622 to 0x652 according to the website there are 49 characters in total for which mapping should be present, but currently there are only 43 entries in doubleCharRemappings array in /batik/gvt/text/ArabicTextHandler.java file

These 6 characters are missing from the map 

| ت | 1578 | 0000011000101010 | 62a | 3052 | &#1578; |
| - | ---- | ---------------- | --- | ---- | ------- |
| ث | 1579 | 0000011000101011 | 62b | 3053 | &#1579; |
| ج | 1580 | 0000011000101100 | 62c | 3054 | &#1580; |
| ح | 1581 | 0000011000101101 | 62d | 3055 | &#1581; |
| خ | 1582 | 0000011000101110 | 62e | 3056 | &#1582; |
| د | 1583 | 0000011000101111 | 62f | 3057 | &#1583; |
