### PR TITLE
replace StringBuffer with StringBuilder

### DIFF
--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedLengthList.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedLengthList.java
@@ -411,7 +411,7 @@ public class SVGOMAnimatedLengthList
             if (itemList.size() == 0) {
                 return "";
             }
-            StringBuffer sb = new StringBuffer( itemList.size() * 8 );
+            StringBuilder sb = new StringBuilder( itemList.size() * 8 );
             Iterator i = itemList.iterator();
             if (i.hasNext()) {
                 sb.append(((SVGItem) i.next()).getValueAsString());

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedNumberList.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedNumberList.java
@@ -391,7 +391,7 @@ public class SVGOMAnimatedNumberList
             if (itemList.size() == 0) {
                 return "";
             }
-            StringBuffer sb = new StringBuffer( itemList.size() * 8 );
+            StringBuilder sb = new StringBuilder( itemList.size() * 8 );
             Iterator i = itemList.iterator();
             if (i.hasNext()) {
                 sb.append(((SVGItem) i.next()).getValueAsString());

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedPathData.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedPathData.java
@@ -526,7 +526,7 @@ public class SVGOMAnimatedPathData
             if (itemList.size() == 0) {
                 return "";
             }
-            StringBuffer sb = new StringBuffer( itemList.size() * 8 );
+            StringBuilder sb = new StringBuilder( itemList.size() * 8 );
             Iterator i = itemList.iterator();
             if (i.hasNext()) {
                 sb.append(((SVGItem) i.next()).getValueAsString());

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedPoints.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedPoints.java
@@ -362,7 +362,7 @@ public class SVGOMAnimatedPoints
             if (itemList.size() == 0) {
                 return "";
             }
-            StringBuffer sb = new StringBuffer( itemList.size() * 8 );
+            StringBuilder sb = new StringBuilder( itemList.size() * 8 );
             Iterator i = itemList.iterator();
             if (i.hasNext()) {
                 sb.append(((SVGItem) i.next()).getValueAsString());

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedTransformList.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMAnimatedTransformList.java
@@ -360,7 +360,7 @@ public class SVGOMAnimatedTransformList
             if (itemList.size() == 0) {
                 return "";
             }
-            StringBuffer sb = new StringBuffer( itemList.size() * 8 );
+            StringBuilder sb = new StringBuilder( itemList.size() * 8 );
             Iterator i = itemList.iterator();
             if (i.hasNext()) {
                 sb.append(((SVGItem) i.next()).getValueAsString());

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMDocument.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMDocument.java
@@ -178,7 +178,7 @@ public class SVGOMDocument
      * <b>DOM</b>: Implements {@link SVGDocument#getTitle()}.
      */
     public String getTitle() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         boolean preserve = false;
 
         for (Node n = getDocumentElement().getFirstChild();

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMStyleElement.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SVGOMStyleElement.java
@@ -122,7 +122,7 @@ public class SVGOMStyleElement
                 String text = "";
                 Node n = getFirstChild();
                 if (n != null) {
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     while (n != null) {
                         if (n.getNodeType() == Node.CDATA_SECTION_NODE
                             || n.getNodeType() == Node.TEXT_NODE)

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableLengthListValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableLengthListValue.java
@@ -209,7 +209,7 @@ public class AnimatableLengthListValue extends AnimatableValue {
      * Length lists can never be used for CSS properties.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (lengthValues.length > 0) {
             sb.append(formatNumber(lengthValues[0]));
             sb.append(AnimatableLengthValue.UNITS[lengthTypes[0] - 1]);

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableMotionPointValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableMotionPointValue.java
@@ -157,7 +157,7 @@ public class AnimatableMotionPointValue extends AnimatableValue {
      * Returns a string representation of this object.
      */
     public String toStringRep() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(formatNumber(x));
         sb.append(',');
         sb.append(formatNumber(y));

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberListValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberListValue.java
@@ -140,7 +140,7 @@ public class AnimatableNumberListValue extends AnimatableValue {
      * Returns the CSS text representation of the value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(numbers[0]);
         for (int i = 1; i < numbers.length; i++) {
             sb.append(' ');

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberOptionalNumberValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberOptionalNumberValue.java
@@ -163,7 +163,7 @@ public class AnimatableNumberOptionalNumberValue extends AnimatableValue {
      * Returns the CSS text representation of the value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(formatNumber(number));
         if (hasOptionalNumber) {
             sb.append(' ');

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberOrPercentageValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableNumberOrPercentageValue.java
@@ -145,7 +145,7 @@ public class AnimatableNumberOrPercentageValue extends AnimatableNumberValue {
      * Returns the CSS text representation of the value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(formatNumber(value));
         if (isPercentage) {
             sb.append('%');

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatablePathDataValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatablePathDataValue.java
@@ -184,7 +184,7 @@ public class AnimatablePathDataValue extends AnimatableValue {
      * Returns a string representation of this object.
      */
     public String toStringRep() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int k = 0;
         for (short command : commands) {
             sb.append(PATH_COMMANDS[command]);

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableRectValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableRectValue.java
@@ -164,7 +164,7 @@ public class AnimatableRectValue extends AnimatableValue {
      * Returns a string representation of this object.
      */
     public String toStringRep() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(x);
         sb.append(',');
         sb.append(y);

--- a/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableTransformListValue.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/values/AnimatableTransformListValue.java
@@ -557,7 +557,7 @@ public class AnimatableTransformListValue extends AnimatableValue {
      * Returns the CSS text representation of the value.
      */
     public String toStringRep() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Iterator i = transforms.iterator();
         while (i.hasNext()) {
             AbstractSVGTransform t = (AbstractSVGTransform) i.next();

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/IndexImage.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/IndexImage.java
@@ -267,7 +267,7 @@ public class IndexImage{
 //            if ( flagChangedLo || flagChangedHi ){
 //                System.out.println("old min:" + min[ splitChannel ] + "/max:" + max[ splitChannel ]
 //                + " new: " + loBound + "/" + hiBound );
-//                StringBuffer buff = new StringBuffer( 100 );
+//                StringBuilder buff = new StringBuilder( 100 );
 //                for( int i= min[ splitChannel ]; i <= max[ splitChannel]; i++ ){
 //                    buff.append( counts[ i ] );
 //                    buff.append( ',' );
@@ -592,7 +592,7 @@ public class IndexImage{
      */
     static void logRGB( byte[] r, byte[] g, byte[] b ){
 
-        StringBuffer buff = new StringBuffer( 100 );
+        StringBuilder buff = new StringBuilder( 100 );
         int nColors = r.length;
         for( int i= 0; i < nColors; i++ ) {
             String rgbStr= "(" + (r[i]+128) + ',' + (g[i] +128 ) + ',' + (b[i] + 128) + ")," ;

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/swing/DoubleDocument.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/swing/DoubleDocument.java
@@ -65,7 +65,7 @@ public class DoubleDocument extends PlainDocument {
         // Now, test that new value is within range.
         String added = new String(digit, 0, j);
         try{
-            StringBuffer val = new StringBuffer(curVal);
+            StringBuilder val = new StringBuilder(curVal);
             val.insert(offs, added);
             String valStr = val.toString();
             if( valStr.equals(".") || valStr.equals("-") || valStr.equals("-."))

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/BaseScriptingEnvironment.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/BaseScriptingEnvironment.java
@@ -544,7 +544,7 @@ public class BaseScriptingEnvironment {
                 // Inline script.
                 Node n = script.getFirstChild();
                 if (n != null) {
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     while (n != null) {
                         if (n.getNodeType() == Node.CDATA_SECTION_NODE
                             || n.getNodeType() == Node.TEXT_NODE)

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/RhinoInterpreter.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/RhinoInterpreter.java
@@ -182,7 +182,7 @@ public class RhinoInterpreter implements Interpreter {
                 if (ii == null) ii = ImportInfo.getImports();
 
                 // import Java lang package & DOM Level 3 & SVG DOM packages
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 Iterator iter;
                 iter = ii.getPackages();
                 while (iter.hasNext()) {

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGFontElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGFontElementBridge.java
@@ -81,7 +81,7 @@ public class SVGFontElementBridge extends AbstractSVGBridge {
             if (glyphCodes[i].length() > 1) {
                 // ligature, may need to reverse if arabic so that it is in visual order
                 if (ArabicTextHandler.arabicChar(glyphCodes[i].charAt(0))) {
-                    glyphCodes[i] = (new StringBuffer(glyphCodes[i])).reverse().toString();
+                    glyphCodes[i] = (new StringBuilder(glyphCodes[i])).reverse().toString();
                 }
             }
             glyphNames[i] = glyphElement.getAttributeNS(null, SVG_GLYPH_NAME_ATTRIBUTE);

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGGVTFont.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGGVTFont.java
@@ -681,7 +681,7 @@ public final class SVGGVTFont implements GVTFont, SVGConstants {
                                             CharacterIterator ci) {
         // construct a string from the glyphCodes
         int nGlyphs = glyphCodes.length;
-        StringBuffer workBuff = new StringBuffer( nGlyphs );
+        StringBuilder workBuff = new StringBuilder( nGlyphs );
         for (int glyphCode : glyphCodes) {
             workBuff.append(glyphUnicodes[glyphCode]);
         }

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGTextElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGTextElementBridge.java
@@ -846,8 +846,8 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
     protected AttributedString buildAttributedString(BridgeContext ctx,
                                                      Element element) {
 
-        AttributedStringBuffer asb = new AttributedStringBuffer();
-        fillAttributedStringBuffer(ctx, element, true, null, null, null, asb);
+        AttributedStringBuilder asb = new AttributedStringBuilder();
+        fillAttributedStringBuilder(ctx, element, true, null, null, null, asb);
         return asb.toAttributedString();
     }
 
@@ -861,15 +861,15 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
     protected int endLimit;
 
     /**
-     * Fills the given AttributedStringBuffer.
+     * Fills the given AttributedStringBuilder.
      */
-    protected void fillAttributedStringBuffer(BridgeContext ctx,
+    protected void fillAttributedStringBuilder(BridgeContext ctx,
                                               Element element,
                                               boolean top,
                                               TextPath textPath,
                                               Integer bidiLevel,
                                               Map initialAttributes,
-                                              AttributedStringBuffer asb) {
+                                              AttributedStringBuilder asb) {
         // 'requiredFeatures', 'requiredExtensions', 'systemLanguage' &
         // 'display="none".
         if ((!SVGUtilities.matchUserAgent(element, ctx.getUserAgent())) ||
@@ -927,7 +927,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
                 if (ln.equals(SVG_TSPAN_TAG) ||
                     ln.equals(SVG_ALT_GLYPH_TAG)) {
                     int before = asb.count;
-                    fillAttributedStringBuffer(ctx,
+                    fillAttributedStringBuilder(ctx,
                                                nodeElement,
                                                false,
                                                textPath,
@@ -944,7 +944,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
                         = textPathBridge.createTextPath(ctx, nodeElement);
                     if (newTextPath != null) {
                         int before = asb.count;
-                        fillAttributedStringBuffer(ctx,
+                        fillAttributedStringBuilder(ctx,
                                                    nodeElement,
                                                    false,
                                                    newTextPath,
@@ -991,7 +991,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
                          SVG_EVENT_CLICK, l, false);
 
                     int before = asb.count;
-                    fillAttributedStringBuffer(ctx,
+                    fillAttributedStringBuilder(ctx,
                                                nodeElement,
                                                false,
                                                textPath,
@@ -1046,7 +1046,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
     protected String normalizeString(String s,
                                      boolean preserve,
                                      boolean stripfirst) {
-        StringBuffer sb = new StringBuffer(s.length());
+        StringBuilder sb = new StringBuilder(s.length());
         if (preserve) {
             for (int i = 0; i < s.length(); i++) {
                 char c = s.charAt(i);
@@ -1104,7 +1104,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
     /**
      * This class is used to build an AttributedString.
      */
-    protected static class AttributedStringBuffer {
+    protected static class AttributedStringBuilder {
 
         /**
          * The strings.
@@ -1127,9 +1127,9 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
         protected int length;
 
         /**
-         * Creates a new empty AttributedStringBuffer.
+         * Creates a new empty AttributedStringBuilder.
          */
-        public AttributedStringBuffer() {
+        public AttributedStringBuilder() {
             strings    = new ArrayList();
             attributes = new ArrayList();
             count      = 0;
@@ -1137,7 +1137,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
         }
 
         /**
-         * Tells whether this AttributedStringBuffer is empty.
+         * Tells whether this AttributedStringBuilder is empty.
          */
         public boolean isEmpty() {
             return count == 0;
@@ -1224,7 +1224,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
                                             (Map)attributes.get(0));
             }
 
-            StringBuffer sb = new StringBuffer( strings.size() * 5 );
+            StringBuilder sb = new StringBuilder( strings.size() * 5 );
             for (Object string : strings) {
                 sb.append((String) string);
             }
@@ -1261,7 +1261,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
                 return (String)strings.get(0);
             }
 
-            StringBuffer sb = new StringBuffer( strings.size() * 5 );
+            StringBuilder sb = new StringBuilder( strings.size() * 5 );
             for (Object string : strings) {
                 sb.append((String) string);
             }

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/ScriptingEnvironment.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/ScriptingEnvironment.java
@@ -1097,7 +1097,7 @@ public class ScriptingEnvironment extends BaseScriptingEnvironment {
                                 }
                             }
                             r = new BufferedReader(r);
-                            final StringBuffer sb = new StringBuffer();
+                            final StringBuilder sb = new StringBuilder();
                             int read;
                             char[] buf = new char[4096];
                             while ((read = r.read(buf, 0, buf.length)) != -1) {
@@ -1224,7 +1224,7 @@ public class ScriptingEnvironment extends BaseScriptingEnvironment {
                                 r = new InputStreamReader(is, e);
                             r = new BufferedReader(r);
 
-                            final StringBuffer sb = new StringBuffer();
+                            final StringBuilder sb = new StringBuilder();
                             int read;
                             char[] buf = new char[4096];
                             while ((read = r.read(buf, 0, buf.length)) != -1) {

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/TextNode.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/TextNode.java
@@ -153,7 +153,7 @@ public class TextNode extends AbstractGraphicsNode implements Selectable {
         if (aci == null) {
             text = "";
         } else {
-            StringBuffer buf = new StringBuffer(aci.getEndIndex());
+            StringBuilder buf = new StringBuilder(aci.getEndIndex());
             for (char c = aci.first();
                  c != CharacterIterator.DONE;
                  c = aci.next()) {

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/TextUtilities.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/TextUtilities.java
@@ -42,7 +42,7 @@ public abstract class TextUtilities implements CSSConstants, ErrorConstants {
      * Returns the content of the given element.
      */
     public static String getElementContent(Element e) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (Node n = e.getFirstChild();
              n != null;
              n = n.getNextSibling()) {

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/svg12/SVGFlowRootElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/svg12/SVGFlowRootElementBridge.java
@@ -427,8 +427,8 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
     protected void dumpACIWord(AttributedString as) {
         if (as == null) return;
 
-        StringBuffer chars = new StringBuffer();
-        StringBuffer brkStr = new StringBuffer();
+        StringBuilder chars = new StringBuilder();
+        StringBuilder brkStr = new StringBuilder();
         AttributedCharacterIterator aci = as.getIterator();
         AttributedCharacterIterator.Attribute WORD_LIMIT =
             TextLineBreaks.WORD_LIMIT;
@@ -488,7 +488,7 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
         divTPI.fillPaint = Color.black;
         elemTPI.put(div, divTPI);
 
-        AttributedStringBuffer asb = new AttributedStringBuffer();
+        AttributedStringBuilder asb = new AttributedStringBuilder();
         List paraEnds  = new ArrayList();
         List paraElems = new ArrayList();
         List lnLocs    = new ArrayList();
@@ -504,13 +504,13 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
 
             String ln = e.getLocalName();
             if (ln.equals(SVG12Constants.SVG_FLOW_PARA_TAG)) {
-                fillAttributedStringBuffer
+                fillAttributedStringBuilder
                     (ctx, e, true, null, null, asb, lnLocs);
 
                 paraElems.add(e);
                 paraEnds.add(asb.length());
             } else if (ln.equals(SVG12Constants.SVG_FLOW_REGION_BREAK_TAG)) {
-                fillAttributedStringBuffer
+                fillAttributedStringBuilder
                     (ctx, e, true, null, null, asb, lnLocs);
 
                 paraElems.add(e);
@@ -619,14 +619,14 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
     protected int startLen;
 
     /**
-     * Fills the given AttributedStringBuffer.
+     * Fills the given AttributedStringBuilder.
      */
-    protected void fillAttributedStringBuffer(BridgeContext ctx,
+    protected void fillAttributedStringBuilder(BridgeContext ctx,
                                               Element element,
                                               boolean top,
                                               Integer bidiLevel,
                                               Map initialAttributes,
-                                              AttributedStringBuffer asb,
+                                              AttributedStringBuilder asb,
                                               List lnLocs) {
         // 'requiredFeatures', 'requiredExtensions', 'systemLanguage' &
         // 'display="none".
@@ -698,7 +698,7 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
 
                 if (ln.equals(SVG12Constants.SVG_FLOW_LINE_TAG)) {
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     // System.out.println("Line: " + asb.length() +
@@ -711,7 +711,7 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
                 } else if (ln.equals(SVG12Constants.SVG_FLOW_SPAN_TAG) ||
                            ln.equals(SVG12Constants.SVG_ALT_GLYPH_TAG)) {
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     if (asb.length() != before) {
@@ -743,7 +743,7 @@ public class SVGFlowRootElementBridge extends SVG12TextElementBridge {
                              false, null);
                     }
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     if (asb.length() != before) {

--- a/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGImageDecoder.java
+++ b/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGImageDecoder.java
@@ -1221,13 +1221,13 @@ class PNGImage extends SimpleRenderedImage {
     private void parse_tEXt_chunk(PNGChunk chunk) {
 
         byte b;
-        StringBuffer key = new StringBuffer();
+        StringBuilder key = new StringBuilder();
         int textIndex = 0;
         while ((b = chunk.getByte(textIndex++)) != 0) {
             key.append( (char)b );
         }
 
-        StringBuffer value= new StringBuffer();
+        StringBuilder value= new StringBuilder();
         for (int i = textIndex; i < chunk.getLength(); i++) {
             value.append( (char)chunk.getByte(i) );
         }
@@ -1340,14 +1340,14 @@ class PNGImage extends SimpleRenderedImage {
     private void parse_zTXt_chunk(PNGChunk chunk) {
 
         int textIndex = 0;
-        StringBuffer key = new StringBuffer();
+        StringBuilder key = new StringBuilder();
         byte b;
         while ((b = chunk.getByte(textIndex++)) != 0) {
             key.append( (char)b );
         }
         /* int method = */ chunk.getByte(textIndex++);
 
-        StringBuffer value = new StringBuffer();
+        StringBuilder value = new StringBuilder();
         try {
             int length = chunk.getLength() - textIndex;
             byte[] data = chunk.getData();

--- a/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGRed.java
+++ b/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGRed.java
@@ -1230,8 +1230,8 @@ public class PNGRed extends AbstractRed {
     }
 
     private void parse_tEXt_chunk(PNGChunk chunk) {
-        StringBuffer key = new StringBuffer();
-        StringBuffer value = new StringBuffer();
+        StringBuilder key = new StringBuilder();
+        StringBuilder value = new StringBuilder();
         byte b;
 
         int textIndex = 0;
@@ -1349,8 +1349,8 @@ public class PNGRed extends AbstractRed {
     }
 
     private void parse_zTXt_chunk(PNGChunk chunk) {
-        StringBuffer key = new StringBuffer();
-        StringBuffer value = new StringBuffer();
+        StringBuilder key = new StringBuilder();
+        StringBuilder value = new StringBuilder();
         byte b;
 
         int textIndex = 0;

--- a/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/util/SeekableStream.java
+++ b/batik-codec/src/main/java/org/apache/batik/ext/awt/image/codec/util/SeekableStream.java
@@ -867,7 +867,7 @@ public abstract class SeekableStream extends InputStream implements DataInput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final String readLine() throws IOException {
-        StringBuffer input = new StringBuffer();
+        StringBuilder input = new StringBuilder();
         int c = -1;
         boolean eol = false;
 

--- a/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMComputedStyle.java
+++ b/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMComputedStyle.java
@@ -73,7 +73,7 @@ public class CSSOMComputedStyle implements CSSStyleDeclaration {
      * org.w3c.dom.css.CSSStyleDeclaration#getCssText()}.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < cssEngine.getNumberOfProperties(); i++) {
             sb.append(cssEngine.getPropertyName(i));
             sb.append(": ");

--- a/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMSVGColor.java
+++ b/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMSVGColor.java
@@ -639,7 +639,7 @@ public class CSSOMSVGColor
          * Called when the red value text has changed.
          */
         public void redTextChanged(String text) throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -671,7 +671,7 @@ public class CSSOMSVGColor
          */
         public void redFloatValueChanged(short unit, float fValue)
             throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -703,7 +703,7 @@ public class CSSOMSVGColor
          * Called when the green value text has changed.
          */
         public void greenTextChanged(String text) throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -736,7 +736,7 @@ public class CSSOMSVGColor
          */
         public void greenFloatValueChanged(short unit, float fValue)
             throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -768,7 +768,7 @@ public class CSSOMSVGColor
          * Called when the blue value text has changed.
          */
         public void blueTextChanged(String text) throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -801,7 +801,7 @@ public class CSSOMSVGColor
          */
         public void blueFloatValueChanged(short unit, float fValue)
             throws DOMException {
-            StringBuffer sb = new StringBuffer(40);
+            StringBuilder sb = new StringBuilder(40);
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR:
@@ -894,8 +894,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 sb.append(cp);
                 ICCColor iccc = (ICCColor)value.item(1);
@@ -920,8 +920,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());
@@ -942,8 +942,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());
@@ -966,8 +966,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());
@@ -998,8 +998,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());
@@ -1030,8 +1030,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());
@@ -1060,8 +1060,8 @@ public class CSSOMSVGColor
             Value value = getValue();
             switch (getColorType()) {
             case SVG_COLORTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer( value.item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder( value.item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)value.item(1);
                 sb.append(iccc.getColorProfile());

--- a/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMSVGPaint.java
+++ b/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMSVGPaint.java
@@ -540,8 +540,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorProfileChanged(String cp) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 sb.append(cp);
                 ICCColor iccc = (ICCColor)getValue().item(1);
@@ -554,7 +554,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -580,8 +580,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorsCleared() throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -590,7 +590,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -612,8 +612,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorsInitialized(float f) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -624,7 +624,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -648,8 +648,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorInsertedBefore(float f, int idx) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -668,7 +668,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -700,8 +700,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorReplaced(float f, int idx) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -720,7 +720,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -752,8 +752,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorRemoved(int idx) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -770,7 +770,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");
@@ -800,8 +800,8 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
         public void colorAppend(float f) throws DOMException {
             switch (getPaintType()) {
             case SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR:
-                StringBuffer sb =
-                    new StringBuffer(getValue().item(0).getCssText());
+                StringBuilder sb =
+                    new StringBuilder(getValue().item(0).getCssText());
                 sb.append(" icc-color(");
                 ICCColor iccc = (ICCColor)getValue().item(1);
                 sb.append(iccc.getColorProfile());
@@ -816,7 +816,7 @@ public class CSSOMSVGPaint extends CSSOMSVGColor implements SVGPaint {
                 break;
 
             case SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR:
-                sb = new StringBuffer(getValue().item(0).getCssText());
+                sb = new StringBuilder(getValue().item(0).getCssText());
                 sb.append( ' ' );
                 sb.append(getValue().item(1).getCssText());
                 sb.append(" icc-color(");

--- a/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMValue.java
+++ b/batik-css/src/main/java/org/apache/batik/css/dom/CSSOMValue.java
@@ -939,7 +939,7 @@ public class CSSOMValue
         public void listTextChanged(int idx, String text) throws DOMException {
             ListValue lv = (ListValue)getValue();
             int len = lv.getLength();
-            StringBuffer sb = new StringBuffer( len * 8 );
+            StringBuilder sb = new StringBuilder( len * 8 );
             for (int i = 0; i < idx; i++) {
                 sb.append(lv.item(i).getCssText());
                 sb.append(lv.getSeparatorChar());
@@ -960,7 +960,7 @@ public class CSSOMValue
             throws DOMException {
             ListValue lv = (ListValue)getValue();
             int len = lv.getLength();
-            StringBuffer sb = new StringBuffer( len * 8 );
+            StringBuilder sb = new StringBuilder( len * 8 );
             for (int i = 0; i < idx; i++) {
                 sb.append(lv.item(i).getCssText());
                 sb.append(lv.getSeparatorChar());
@@ -980,7 +980,7 @@ public class CSSOMValue
             throws DOMException {
             ListValue lv = (ListValue)getValue();
             int len = lv.getLength();
-            StringBuffer sb = new StringBuffer( len * 8 );
+            StringBuilder sb = new StringBuilder( len * 8 );
             for (int i = 0; i < idx; i++) {
                 sb.append(lv.item(i).getCssText());
                 sb.append(lv.getSeparatorChar());

--- a/batik-css/src/main/java/org/apache/batik/css/engine/FontFaceRule.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/FontFaceRule.java
@@ -65,7 +65,7 @@ public class FontFaceRule implements Rule {
      * Returns a printable representation of this rule.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("@font-face { ");
         sb.append(sm.toString(eng));
         sb.append(" }\n");

--- a/batik-css/src/main/java/org/apache/batik/css/engine/ImportRule.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/ImportRule.java
@@ -63,7 +63,7 @@ public class ImportRule extends MediaRule {
      * Returns a printable representation of this import rule.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("@import \"");
         sb.append(uri);
         sb.append("\"");

--- a/batik-css/src/main/java/org/apache/batik/css/engine/MediaRule.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/MediaRule.java
@@ -63,7 +63,7 @@ public class MediaRule extends StyleSheet implements Rule {
      * Returns a printable representation of this media rule.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("@media");
         if (mediaList != null) {
             for (int i = 0; i < mediaList.getLength(); i++) {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/StyleDeclaration.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/StyleDeclaration.java
@@ -149,7 +149,7 @@ public class StyleDeclaration {
      * Returns a printable representation of this style rule.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer( count * 8 );
+        StringBuilder sb = new StringBuilder( count * 8 );
         for (int i = 0; i < count; i++) {
             sb.append(eng.getPropertyName(indexes[i]));
             sb.append(": ");

--- a/batik-css/src/main/java/org/apache/batik/css/engine/StyleMap.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/StyleMap.java
@@ -304,7 +304,7 @@ public class StyleMap {
         // eng.getNumberOfProperties() for StyleMaps that were created
         // by that CSSEngine.
         int nSlots = values.length;
-        StringBuffer sb = new StringBuffer(nSlots * 8);
+        StringBuilder sb = new StringBuilder(nSlots * 8);
         for (int i = 0; i < nSlots; i++) {
             Value v = values[i];
             if (v == null) continue;

--- a/batik-css/src/main/java/org/apache/batik/css/engine/StyleRule.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/StyleRule.java
@@ -82,7 +82,7 @@ public class StyleRule implements Rule {
      * Returns a printable representation of this style rule.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (selectorList != null) {
             sb.append(selectorList.item(0));
             for (int i = 1; i < selectorList.getLength(); i++) {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/StyleSheet.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/StyleSheet.java
@@ -152,7 +152,7 @@ public class StyleSheet {
      * Returns a printable representation of this style-sheet.
      */
     public String toString(CSSEngine eng) {
-        StringBuffer sb = new StringBuffer( size * 8 );
+        StringBuilder sb = new StringBuilder( size * 8 );
         for (int i = 0; i < size; i++) {
             sb.append(rules[i].toString(eng));
         }

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/ListValue.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/ListValue.java
@@ -75,7 +75,7 @@ public class ListValue extends AbstractValue {
      *  A string representation of the current value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer( length * 8 );
+        StringBuilder sb = new StringBuilder( length * 8 );
         if (length > 0) {
             sb.append(items[0].getCssText());
         }

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/css2/FontFamilyManager.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/css2/FontFamilyManager.java
@@ -145,7 +145,7 @@ public class FontFamilyManager extends AbstractValueManager {
                 break;
 
             case LexicalUnit.SAC_IDENT:
-                StringBuffer sb = new StringBuffer(lu.getStringValue());
+                StringBuilder sb = new StringBuilder(lu.getStringValue());
                 lu = lu.getNextLexicalUnit();
                 if (lu != null && isIdentOrNumber(lu)) {
                     do {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/css2/SrcManager.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/css2/SrcManager.java
@@ -150,7 +150,7 @@ public class SrcManager extends IdentifierManager {
                 break;
 
             case LexicalUnit.SAC_IDENT:
-                StringBuffer sb = new StringBuffer(lu.getStringValue());
+                StringBuilder sb = new StringBuilder(lu.getStringValue());
                 lu = lu.getNextLexicalUnit();
                 if (lu != null &&
                     lu.getLexicalUnitType() == LexicalUnit.SAC_IDENT) {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/svg/ICCColor.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/svg/ICCColor.java
@@ -87,7 +87,7 @@ public class ICCColor extends AbstractValue {
      *  A string representation of the current value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer( count * 8 );
+        StringBuilder sb = new StringBuilder( count * 8 );
         sb.append(ICC_COLOR_FUNCTION).append('(');
         sb.append(colorProfile);
         for (int i = 0; i < count; i++) {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/AbstractCIEColor.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/AbstractCIEColor.java
@@ -83,7 +83,7 @@ public abstract class AbstractCIEColor extends AbstractValue {
      *  A string representation of the current value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer(getFunctionName());
+        StringBuilder sb = new StringBuilder(getFunctionName());
         sb.append('(');
         sb.append(values[0]);
         sb.append(", ");

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/DeviceColor.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/DeviceColor.java
@@ -88,7 +88,7 @@ public class DeviceColor extends AbstractValue {
      *  A string representation of the current value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer( count * 8 );
+        StringBuilder sb = new StringBuilder( count * 8 );
         if (nChannel) {
             sb.append(DEVICE_NCHANNEL_COLOR_FUNCTION);
         } else {

--- a/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/ICCNamedColor.java
+++ b/batik-css/src/main/java/org/apache/batik/css/engine/value/svg12/ICCNamedColor.java
@@ -75,7 +75,7 @@ public class ICCNamedColor extends AbstractValue {
      *  A string representation of the current value.
      */
     public String getCssText() {
-        StringBuffer sb = new StringBuffer(ICC_NAMED_COLOR_FUNCTION);
+        StringBuilder sb = new StringBuilder(ICC_NAMED_COLOR_FUNCTION);
         sb.append('(');
         sb.append(colorProfile);
         sb.append(", ");

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractAttr.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractAttr.java
@@ -119,7 +119,7 @@ public abstract class AbstractAttr extends AbstractParentNode implements Attr {
         if (n == null) {
             return first.getNodeValue();
         }
-        StringBuffer result = new StringBuffer(first.getNodeValue());
+        StringBuilder result = new StringBuilder(first.getNodeValue());
         do {
             result.append(n.getNodeValue());
             n = n.getNextSibling();

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
@@ -1296,7 +1296,7 @@ public abstract class AbstractDocument
                     || !cdataSections && nt == Node.CDATA_SECTION_NODE) {
                 // coalesce text nodes
                 Node t = n;
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append(t.getNodeValue());
                 n = n.getNextSibling();
                 while (n != null && (n.getNodeType() == Node.TEXT_NODE

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractParentNode.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractParentNode.java
@@ -304,7 +304,7 @@ public abstract class AbstractParentNode extends AbstractNode {
      * <b>DOM</b>: Implements {@link org.w3c.dom.Node#getTextContent()}.
      */
     public String getTextContent() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (Node n = getFirstChild(); n != null; n = n.getNextSibling()) {
             switch (n.getNodeType()) {
                 case COMMENT_NODE:

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractText.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractText.java
@@ -130,7 +130,7 @@ public abstract class AbstractText
      * <b>DOM</b>: Implements {@link org.w3c.dom.Text#getWholeText()}.
      */
     public String getWholeText() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (Node n = this;
                 n != null;
                 n = getPreviousLogicallyAdjacentTextNode(n)) {

--- a/batik-dom/src/main/java/org/apache/batik/dom/events/DOMMouseEvent.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/events/DOMMouseEvent.java
@@ -157,7 +157,7 @@ public class DOMMouseEvent extends DOMUIEvent implements MouseEvent {
         if (modifierKeys.isEmpty()) {
             return "";
         }
-        StringBuffer sb = new StringBuffer(modifierKeys.size() * 8);
+        StringBuilder sb = new StringBuilder(modifierKeys.size() * 8);
         Iterator i = modifierKeys.iterator();
         sb.append((String) i.next());
         while (i.hasNext()) {

--- a/batik-dom/src/main/java/org/apache/batik/dom/events/DOMUIEvent.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/events/DOMUIEvent.java
@@ -100,7 +100,7 @@ public class DOMUIEvent extends AbstractEvent implements UIEvent {
      */
     protected String[] split(String s) {
         List a = new ArrayList(8);
-        StringBuffer sb;
+        StringBuilder sb;
         int i = 0;
         int len = s.length();
         while (i < len) {
@@ -108,7 +108,7 @@ public class DOMUIEvent extends AbstractEvent implements UIEvent {
             if (XMLUtilities.isXMLSpace(c)) {
                 continue;
             }
-            sb = new StringBuffer();
+            sb = new StringBuilder();
             sb.append(c);
             while (i < len) {
                 c = s.charAt(i++);

--- a/batik-dom/src/main/java/org/apache/batik/dom/util/DOMUtilities.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/util/DOMUtilities.java
@@ -442,7 +442,7 @@ public class DOMUtilities extends XMLUtilities implements XMLConstants {
     public static String contentToString(String s, boolean isXML11)
             throws IOException {
 
-        StringBuffer result = new StringBuffer(s.length());
+        StringBuilder result = new StringBuilder(s.length());
 
         int len = s.length();
         for (int i = 0; i < len; i++) {
@@ -702,7 +702,7 @@ public class DOMUtilities extends XMLUtilities implements XMLConstants {
         }
 
         // Try and parse as a document fragment
-        StringBuffer sb = new StringBuffer(wrapperElementPrefix.length()
+        StringBuilder sb = new StringBuilder(wrapperElementPrefix.length()
                 + text.length() + wrapperElementSuffix.length());
         sb.append(wrapperElementPrefix);
         sb.append(text);
@@ -873,7 +873,7 @@ public class DOMUtilities extends XMLUtilities implements XMLConstants {
                 throw new DOMException(DOMException.INVALID_CHARACTER_ERR,
                                        "Wrong name initial:  " + c);
             }
-            StringBuffer ident = new StringBuffer();
+            StringBuilder ident = new StringBuilder();
             ident.append(c);
             while (++i < data.length()) {
                 c = data.charAt(i);
@@ -921,7 +921,7 @@ public class DOMUtilities extends XMLUtilities implements XMLConstants {
             // The next char must be '\'' or '"'
             c = data.charAt(i);
             i++;
-            StringBuffer value = new StringBuffer();
+            StringBuilder value = new StringBuilder();
             if (c == '\'') {
                 while (i < data.length()) {
                     c = data.charAt(i);

--- a/batik-dom/src/main/java/org/apache/batik/dom/util/SAXDocumentFactory.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/util/SAXDocumentFactory.java
@@ -106,7 +106,7 @@ public class SAXDocumentFactory
     /**
      * Contains collected string data.  May be Text, CDATA or Comment.
      */
-    protected StringBuffer stringBuffer = new StringBuffer();
+    protected StringBuilder stringBuilder = new StringBuilder();
 
     /**
      * The DTD to use when the document is created.
@@ -114,7 +114,7 @@ public class SAXDocumentFactory
     protected DocumentType doctype;
 
     /**
-     * Indicates if stringBuffer has content, needed in case of
+     * Indicates if stringBuilder has content, needed in case of
      * zero sized "text" content.
      */
     protected boolean stringContent;
@@ -558,7 +558,7 @@ public class SAXDocumentFactory
         isStandalone = false;
         xmlVersion   = XMLConstants.XML_VERSION_10;
 
-        stringBuffer.setLength(0);
+        stringBuilder.setLength(0);
         stringContent = false;
 
         if (createDocumentDescriptor) {
@@ -693,8 +693,8 @@ public class SAXDocumentFactory
     public void appendStringData() {
         if (!stringContent) return;
 
-        String str = stringBuffer.toString();
-        stringBuffer.setLength(0); // reuse buffer.
+        String str = stringBuilder.toString();
+        stringBuilder.setLength(0); // reuse buffer.
         stringContent = false;
         if (currentNode == null) {
             if (inCDATA) preInfo.add(new CDataInfo(str));
@@ -713,7 +713,7 @@ public class SAXDocumentFactory
      */
     public void characters(char[] ch, int start, int length)
         throws SAXException {
-        stringBuffer.append(ch, start, length);
+        stringBuilder.append(ch, start, length);
         stringContent = true;
     }
 
@@ -726,7 +726,7 @@ public class SAXDocumentFactory
                                     int start,
                                     int length)
         throws SAXException {
-        stringBuffer.append(ch, start, length);
+        stringBuilder.append(ch, start, length);
         stringContent = true;
     }
 

--- a/batik-dom/src/main/java/org/apache/batik/dom/util/XMLSupport.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/util/XMLSupport.java
@@ -84,7 +84,7 @@ public final class XMLSupport implements XMLConstants {
      */
     public static String defaultXMLSpace(String data) {
         int nChars = data.length();
-        StringBuffer result = new StringBuffer( nChars );
+        StringBuilder result = new StringBuilder( nChars );
         boolean space = false;
         for (int i = 0; i < nChars; i++) {
             char c = data.charAt(i);
@@ -114,7 +114,7 @@ public final class XMLSupport implements XMLConstants {
      */
     public static String preserveXMLSpace(String data) {
         int nChars = data.length();
-        StringBuffer result = new StringBuffer( nChars );
+        StringBuilder result = new StringBuilder( nChars );
         for (int i = 0; i < data.length(); i++) {
             char c = data.charAt(i);
             switch (c) {

--- a/batik-extension/src/main/java/org/apache/batik/extension/svg/BatikFlowTextElementBridge.java
+++ b/batik-extension/src/main/java/org/apache/batik/extension/svg/BatikFlowTextElementBridge.java
@@ -321,7 +321,7 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
         divTPI.fillPaint = Color.black;
         elemTPI.put(div, divTPI);
 
-        AttributedStringBuffer asb = new AttributedStringBuffer();
+        AttributedStringBuilder asb = new AttributedStringBuilder();
         List paraEnds  = new ArrayList();
         List paraElems = new ArrayList();
         List lnLocs    = new ArrayList();
@@ -337,13 +337,13 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
 
             String ln = e.getLocalName();
             if (ln.equals(BATIK_EXT_FLOW_PARA_TAG)) {
-                fillAttributedStringBuffer
+                fillAttributedStringBuilder
                     (ctx, e, true, null, null, asb, lnLocs);
 
                 paraElems.add(e);
                 paraEnds.add(asb.length());
             } else if (ln.equals(BATIK_EXT_FLOW_REGION_BREAK_TAG)) {
-                fillAttributedStringBuffer
+                fillAttributedStringBuilder
                         (ctx, e, true, null, null, asb, lnLocs);
 
                 paraElems.add(e);
@@ -510,14 +510,14 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
     }
 
     /**
-     * Fills the given AttributedStringBuffer.
+     * Fills the given AttributedStringBuilder.
      */
-    protected void fillAttributedStringBuffer(BridgeContext ctx,
+    protected void fillAttributedStringBuilder(BridgeContext ctx,
                                               Element element,
                                               boolean top,
                                               Integer bidiLevel,
                                               Map initialAttributes,
-                                              AttributedStringBuffer asb,
+                                              AttributedStringBuilder asb,
                                               List lnLocs) {
         // 'requiredFeatures', 'requiredExtensions', 'systemLanguage' &
         // 'display="none".
@@ -574,7 +574,7 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
 
                 if (ln.equals(BATIK_EXT_FLOW_LINE_TAG)) {
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     // System.out.println("Line: " + asb.length() +
@@ -586,7 +586,7 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
                 } else if (ln.equals(BATIK_EXT_FLOW_SPAN_TAG) ||
                            ln.equals(SVG_ALT_GLYPH_TAG)) {
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     if (asb.length() != before) {
@@ -618,7 +618,7 @@ public class BatikFlowTextElementBridge extends SVGTextElementBridge
                              false, null);
                     }
                     int before = asb.length();
-                    fillAttributedStringBuffer(ctx, nodeElement, false,
+                    fillAttributedStringBuilder(ctx, nodeElement, false,
                                                subBidiLevel, initialAttributes,
                                                asb, lnLocs);
                     if (asb.length() != before) {

--- a/batik-gui-util/src/main/java/org/apache/batik/util/gui/CSSMediaPanel.java
+++ b/batik-gui-util/src/main/java/org/apache/batik/util/gui/CSSMediaPanel.java
@@ -216,7 +216,7 @@ public class CSSMediaPanel extends JPanel implements ActionMap {
      * Returns the media list as a string separated by space.
      */
     public String getMediaAsString() {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         Enumeration e = listModel.elements();
         while (e.hasMoreElements()) {
             buffer.append((String)e.nextElement());

--- a/batik-gui-util/src/main/java/org/apache/batik/util/gui/LanguageDialog.java
+++ b/batik-gui-util/src/main/java/org/apache/batik/util/gui/LanguageDialog.java
@@ -367,7 +367,7 @@ public class LanguageDialog extends JDialog implements ActionMap {
          * Returns the selected user languages.
          */
         public String getLanguages() {
-            StringBuffer result = new StringBuffer();
+            StringBuilder result = new StringBuilder();
             if (userListModel.getSize() > 0) {
                 result.append(userListModel.getElementAt(0));
 

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/text/ArabicTextHandler.java
@@ -106,7 +106,7 @@ public final class ArabicTextHandler {
 
         if (charOrder != null) {
             // need to reconstruct the reordered attributed string
-            StringBuffer reorderedString = new StringBuffer(numChars);
+            StringBuilder reorderedString = new StringBuilder(numChars);
             char c;
             for (int i = 0; i < numChars; i++) {
                 c = aci.setIndex(charOrder[i]);
@@ -435,7 +435,7 @@ public final class ArabicTextHandler {
         int start = aci.getBeginIndex();
         int end   = aci.getEndIndex();
         int numChar = end-start;
-        StringBuffer substString = new StringBuffer(numChar);
+        StringBuilder substString = new StringBuilder(numChar);
         for (int i=start; i< end; i++) {
             char c = aci.setIndex(i);
             if (!arabicChar(c)) {

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/text/BidiAttributedCharacterIterator.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/text/BidiAttributedCharacterIterator.java
@@ -83,7 +83,7 @@ public class BidiAttributedCharacterIterator implements AttributedCharacterItera
             // of null keys/values).
             as = new AttributedString(aci);
         } else {
-            StringBuffer strB = new StringBuffer( numChars );
+            StringBuilder strB = new StringBuilder( numChars );
             char c = aci.first();
             for (int i = 0; i < numChars; i++) {
                 strB.append(c);
@@ -164,7 +164,7 @@ public class BidiAttributedCharacterIterator implements AttributedCharacterItera
                                      numChars, maxBiDi);
 
         // construct the string in the new order
-        StringBuffer reorderedString = new StringBuffer( numChars );
+        StringBuilder reorderedString = new StringBuilder( numChars );
         int reorderedFirstChar = 0;
         for (int i = 0; i < numChars; i++) {
             int srcIdx = newCharOrder[i];

--- a/batik-parser/src/main/java/org/apache/batik/parser/TimingParser.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/TimingParser.java
@@ -107,7 +107,7 @@ public abstract class TimingParser extends AbstractParser {
      * Parses an XML name with optional escaping in the middle.
      */
     protected String parseName() throws ParseException, IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         boolean midEscaped = false;
         do {
             sb.append((char) current);
@@ -158,7 +158,7 @@ public abstract class TimingParser extends AbstractParser {
                 reportUnexpectedCharacterError( current );
             }
             current = reader.read();
-            StringBuffer keyName = new StringBuffer();
+            StringBuilder keyName = new StringBuilder();
             while (current >= 'A' && current <= 'Z'
                     || current >= 'a' && current <= 'z'
                     || current >= '0' && current <= '9'
@@ -431,7 +431,7 @@ public abstract class TimingParser extends AbstractParser {
                     tzn = "UTC";
                     current = reader.read();
                 } else if (current == '+' || current == '-') {
-                    StringBuffer tznb = new StringBuffer();
+                    StringBuilder tznb = new StringBuilder();
                     tzSpecified = true;
                     if (current == '-') {
                         tzNegative = true;

--- a/batik-script/src/main/java/org/apache/batik/script/jacl/JaclInterpreter.java
+++ b/batik-script/src/main/java/org/apache/batik/script/jacl/JaclInterpreter.java
@@ -63,7 +63,7 @@ public class JaclInterpreter implements org.apache.batik.script.Interpreter {
     public Object evaluate(Reader scriptreader, String description)
         throws IOException {
         // oops jacl doesn't accept reader in its eval method :-(
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         char[] buffer = new char[1024];
         int val = 0;
         while ((val = scriptreader.read(buffer)) != -1) {

--- a/batik-script/src/main/java/org/apache/batik/script/jpython/JPythonInterpreter.java
+++ b/batik-script/src/main/java/org/apache/batik/script/jpython/JPythonInterpreter.java
@@ -58,7 +58,7 @@ public class JPythonInterpreter implements org.apache.batik.script.Interpreter {
         throws IOException {
 
         // oups jpython doesn't accept reader in its eval method :-(
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         char[] buffer = new char[1024];
         int val = 0;
         while ((val = scriptreader.read(buffer)) != -1) {

--- a/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGList.java
+++ b/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGList.java
@@ -423,7 +423,7 @@ public abstract class AbstractSVGList {
         Iterator it = value.iterator();
         if (it.hasNext()) {
             SVGItem item = (SVGItem) it.next();
-            StringBuffer buf = new StringBuffer( value.size() * 8 );
+            StringBuilder buf = new StringBuilder( value.size() * 8 );
             buf.append(  item.getValueAsString() );
             while (it.hasNext()) {
                 item = (SVGItem) it.next();

--- a/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGTransformList.java
+++ b/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGTransformList.java
@@ -440,7 +440,7 @@ public abstract class AbstractSVGTransformList
          * Returns the string representation of this transform.
          */
         protected String getStringValue(){
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             switch(type) {
                 case SVGTransform.SVG_TRANSFORM_TRANSLATE:
                     buf.append("translate(");

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/DOMViewer.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/DOMViewer.java
@@ -1808,7 +1808,7 @@ public class DOMViewer extends JFrame implements ActionMap {
             }
 
             protected String createDocumentText(Document doc) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("Nodes: ");
                 sb.append(nodeCount(doc));
                 return sb.toString();

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/Main.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/Main.java
@@ -955,7 +955,7 @@ public class Main implements Application {
         }
 
         // Now, save the list of visited URL into the preferences
-        StringBuffer lastVisitedBuffer = new StringBuffer( lastVisited.size() * 8 );
+        StringBuilder lastVisitedBuffer = new StringBuilder( lastVisited.size() * 8 );
 
         for (Object aLastVisited : lastVisited) {
             try {

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/PreferenceDialog.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/PreferenceDialog.java
@@ -639,7 +639,7 @@ public class PreferenceDialog extends JDialog
                         host.getText());
         model.setString(PREFERENCE_KEY_PROXY_PORT,
                         port.getText());
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Enumeration e = mediaListModel.elements();
         while (e.hasMoreElements()) {
             sb.append((String) e.nextElement());

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/SquiggleInputHandlerFilter.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/SquiggleInputHandlerFilter.java
@@ -40,7 +40,7 @@ public class SquiggleInputHandlerFilter extends FileFilter {
     }
 
     public String getDescription() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String[] extensions = handler.getHandledExtensions();
         int n = extensions != null ? extensions.length : 0;
         for (int i=0; i<n; i++) {

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/XMLPreferenceManager.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/XMLPreferenceManager.java
@@ -128,7 +128,7 @@ public class XMLPreferenceManager extends PreferenceManager {
                     if (n.getNodeName().equals("property")) {
                         String name = ((Element)n).getAttributeNS(null, "name");
                         
-                        StringBuffer cont = new StringBuffer();
+                        StringBuilder cont = new StringBuilder();
                         for (Node c = n.getFirstChild();
                              c != null;
                              c = c.getNextSibling()) {

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGAlphaComposite.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGAlphaComposite.java
@@ -137,7 +137,7 @@ public class SVGAlphaComposite extends AbstractSVGConverter {
                 defSet.add(filterDef);
 
                 // Process the filter value
-                StringBuffer filterAttrBuf = new StringBuffer(URL_PREFIX);
+                StringBuilder filterAttrBuf = new StringBuilder(URL_PREFIX);
                 filterAttrBuf.append(SIGN_POUND);
                 filterAttrBuf.append(filterDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
                 filterAttrBuf.append(URL_SUFFIX);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGArc.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGArc.java
@@ -82,7 +82,7 @@ public class SVGArc extends SVGGraphicObjectConverter {
 
         Element svgPath = generatorContext.domFactory.createElementNS
             (SVG_NAMESPACE_URI, SVG_PATH_TAG);
-        StringBuffer d = new StringBuffer( 64 );
+        StringBuilder d = new StringBuilder( 64 );
 
         Point2D startPt = arc.getStartPoint();
         Point2D endPt   = arc.getEndPoint();

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGBasicStroke.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGBasicStroke.java
@@ -94,7 +94,7 @@ public class SVGBasicStroke extends AbstractSVGConverter{
      * @param dashArray float array to convert to a string
      */
     private final String dashArrayToSVG(float[] dashArray){
-        StringBuffer dashArrayBuf = new StringBuffer( dashArray.length * 8 );
+        StringBuilder dashArrayBuf = new StringBuilder( dashArray.length * 8 );
         if(dashArray.length > 0)
             dashArrayBuf.append(doubleString(dashArray[0]));
 

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCSSStyler.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCSSStyler.java
@@ -54,7 +54,7 @@ public class SVGCSSStyler implements SVGSyntax{
             // Has to be an Element, as it has attributes
             // According to spec.
             Element element = (Element)node;
-            StringBuffer styleAttrBuffer = new StringBuffer();
+            StringBuilder styleAttrBuffer = new StringBuilder();
             int nAttr = attributes.getLength();
             List toBeRemoved = new ArrayList();
             for(int i=0; i<nAttr; i++){

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGClip.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGClip.java
@@ -71,7 +71,7 @@ public class SVGClip extends AbstractSVGConverter {
         SVGClipDescriptor clipDesc = null;
 
         if (clip != null) {
-            StringBuffer clipPathAttrBuf = new StringBuffer(URL_PREFIX);
+            StringBuilder clipPathAttrBuf = new StringBuilder(URL_PREFIX);
 
             // First, convert to a GeneralPath so that the
             GeneralPath clipPath = new GeneralPath(clip);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGColor.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGColor.java
@@ -112,7 +112,7 @@ public class SVGColor extends AbstractSVGConverter{
         String cssColor = (String)colorMap.get(color);
         if (cssColor==null) {
             // color is not one of the predefined colors
-            StringBuffer cssColorBuffer = new StringBuffer(RGB_PREFIX);
+            StringBuilder cssColorBuffer = new StringBuilder(RGB_PREFIX);
             cssColorBuffer.append(color.getRed());
             cssColorBuffer.append(COMMA);
             cssColorBuffer.append(color.getGreen());

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGConvolveOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGConvolveOp.java
@@ -93,7 +93,7 @@ public class SVGConvolveOp extends AbstractSVGFilterConverter {
 
             // Convert the kernel values
             float[] data = kernel.getKernelData(null);
-            StringBuffer kernelMatrixBuf = new StringBuffer( data.length * 8 );
+            StringBuilder kernelMatrixBuf = new StringBuilder( data.length * 8 );
             for (float aData : data) {
                 kernelMatrixBuf.append(doubleString(aData));
                 kernelMatrixBuf.append(SPACE);
@@ -122,7 +122,7 @@ public class SVGConvolveOp extends AbstractSVGFilterConverter {
             //
 
             // Process filter attribute
-            StringBuffer filterAttrBuf = new StringBuffer(URL_PREFIX);
+            StringBuilder filterAttrBuf = new StringBuilder(URL_PREFIX);
             filterAttrBuf.append(SIGN_POUND);
             filterAttrBuf.append(filterDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
             filterAttrBuf.append(URL_SUFFIX);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGFont.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGFont.java
@@ -498,7 +498,7 @@ public class SVGFont extends AbstractSVGConverter {
          * this keeps all added characters in order. It can be cleared from toSVG()
          * when glyphs are created for some characters.
          */
-        private StringBuffer freshChars = new StringBuffer( 40 );
+        private StringBuilder freshChars = new StringBuilder( 40 );
 
         CharListHelper() {
 
@@ -516,7 +516,7 @@ public class SVGFont extends AbstractSVGConverter {
          * reset the string of recently added characters - used after glyphs were created for them.
          */
         void clearNewChars(){
-            freshChars = new StringBuffer( 40 );
+            freshChars = new StringBuilder( 40 );
         }
 
         /**

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGGraphics2D.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGGraphics2D.java
@@ -1319,7 +1319,7 @@ public class SVGGraphics2D extends AbstractGraphics2D
             int start = ati.getIndex();
             int end   = ati.getRunLimit()-1;
 
-            StringBuffer buf = new StringBuffer( end - start );
+            StringBuilder buf = new StringBuilder( end - start );
             buf.append(ch);
 
             for (int i=start; i<end; i++) {

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLinearGradient.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLinearGradient.java
@@ -142,7 +142,7 @@ public class SVGLinearGradient extends AbstractSVGConverter {
             //
             // Build Paint descriptor
             //
-            StringBuffer paintAttrBuf = new StringBuffer(URL_PREFIX);
+            StringBuilder paintAttrBuf = new StringBuilder(URL_PREFIX);
             paintAttrBuf.append(SIGN_POUND);
             paintAttrBuf.append(gradientDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
             paintAttrBuf.append(URL_SUFFIX);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLookupOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLookupOp.java
@@ -196,7 +196,7 @@ public class SVGLookupOp extends AbstractSVGFilterConverter {
             //
 
             // Process filter attribute
-//            StringBuffer filterAttrBuf = new StringBuffer(URL_PREFIX);
+//            StringBuilder filterAttrBuf = new StringBuilder(URL_PREFIX);
 //            filterAttrBuf.append(SIGN_POUND);
 //            filterAttrBuf.append(filterDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
 //            filterAttrBuf.append(URL_SUFFIX);
@@ -223,9 +223,9 @@ public class SVGLookupOp extends AbstractSVGFilterConverter {
         if((nComponents != 1) && (nComponents != 3) && (nComponents != 4))
             throw new SVGGraphics2DRuntimeException(ERR_ILLEGAL_BUFFERED_IMAGE_LOOKUP_OP);
 
-        StringBuffer[] lookupTableBuf = new StringBuffer[nComponents];
+        StringBuilder[] lookupTableBuf = new StringBuilder[nComponents];
         for(int i=0; i<nComponents; i++)
-            lookupTableBuf[i] = new StringBuffer();
+            lookupTableBuf[i] = new StringBuilder();
 
         if(!(lookupTable instanceof ByteLookupTable)){
             int[] src = new int[nComponents];

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPath.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPath.java
@@ -83,7 +83,7 @@ public class SVGPath extends SVGGraphicObjectConverter {
      * @return the value of the corresponding d attribute
      */
      public static String toSVGPathData(Shape path, SVGGeneratorContext gc) {
-        StringBuffer d = new StringBuffer( 40 );
+        StringBuilder d = new StringBuilder( 40 );
         PathIterator pi = path.getPathIterator(null);
         float[] seg = new float[6];
         int segType = 0;
@@ -136,7 +136,7 @@ public class SVGPath extends SVGGraphicObjectConverter {
     /**
      * Appends a coordinate to the path data
      */
-    private static void appendPoint(StringBuffer d, float x, float y, SVGGeneratorContext gc) {
+    private static void appendPoint(StringBuilder d, float x, float y, SVGGeneratorContext gc) {
         d.append(gc.doubleString(x));
         d.append(SPACE);
         d.append(gc.doubleString(y));

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPolygon.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPolygon.java
@@ -45,7 +45,7 @@ public class SVGPolygon extends SVGGraphicObjectConverter {
         Element svgPolygon =
             generatorContext.domFactory.createElementNS(SVG_NAMESPACE_URI,
                                                         SVG_POLYGON_TAG);
-        StringBuffer points = new StringBuffer(" ");
+        StringBuilder points = new StringBuilder(" ");
         PathIterator pi = polygon.getPathIterator(null);
         float[] seg = new float[6];
         while(!pi.isDone()){
@@ -77,7 +77,7 @@ public class SVGPolygon extends SVGGraphicObjectConverter {
     /**
      *  Appends a coordinate to the path data
      */
-    private void appendPoint(StringBuffer points, float x, float y){
+    private void appendPoint(StringBuilder points, float x, float y){
         points.append(doubleString(x));
         points.append(SPACE);
         points.append(doubleString(y));

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGRescaleOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGRescaleOp.java
@@ -178,7 +178,7 @@ public class SVGRescaleOp extends AbstractSVGFilterConverter {
             //
 
             // Process filter attribute
-//            StringBuffer filterAttrBuf = new StringBuffer(URL_PREFIX);
+//            StringBuilder filterAttrBuf = new StringBuilder(URL_PREFIX);
 //            filterAttrBuf.append(SIGN_POUND);
 //            filterAttrBuf.append(filterDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
 //            filterAttrBuf.append(URL_SUFFIX);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGTexturePaint.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGTexturePaint.java
@@ -148,7 +148,7 @@ public class SVGTexturePaint extends AbstractSVGConverter {
                                       generatorContext.idGenerator.
                                       generateID(ID_PREFIX_PATTERN));
 
-//            StringBuffer patternAttrBuf = new StringBuffer(URL_PREFIX);
+//            StringBuilder patternAttrBuf = new StringBuilder(URL_PREFIX);
 //            patternAttrBuf.append(SIGN_POUND);
 //            patternAttrBuf.append(patternDef.getAttributeNS(null, SVG_ID_ATTRIBUTE));
 //            patternAttrBuf.append(URL_SUFFIX);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGTransform.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGTransform.java
@@ -172,7 +172,7 @@ public class SVGTransform extends AbstractSVGConverter{
         //
         int nPresentations = presentation.size();
 
-        StringBuffer transformStackBuffer = new StringBuffer( nPresentations * 8 );
+        StringBuilder transformStackBuffer = new StringBuilder( nPresentations * 8 );
         for(i = 0; i < nPresentations; i++) {
             transformStackBuffer.append(convertTransform((TransformStackElement) presentation.get(i)));
             transformStackBuffer.append(SPACE);
@@ -186,7 +186,7 @@ public class SVGTransform extends AbstractSVGConverter{
      * Converts an AffineTransform to an SVG transform string
      */
     final String convertTransform(TransformStackElement transformElement){
-        StringBuffer transformString = new StringBuffer();
+        StringBuilder transformString = new StringBuilder();
         double[] transformParameters = transformElement.getTransformParameters();
         switch(transformElement.getType().toInt()){
         case TransformType.TRANSFORM_TRANSLATE:

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/SVGFont.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/SVGFont.java
@@ -97,7 +97,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
         "SVGFont.config.svg.test.card.end";
 
     protected static String encodeEntities(String s) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < s.length(); i++) {
             if (s.charAt(i) == XML_CHAR_LT) {
                 sb.append(XML_ENTITY_LT);
@@ -123,7 +123,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
             return "";
         }
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int offset = 0;
 
         while (offset < count) {
@@ -198,7 +198,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
     }
 
     protected static String getSVGFontFaceElement(Font font) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String fontFamily = font.getNameTable().getRecord(Table.nameFontFamilyName);
         short unitsPerEm = font.getHeadTable().getUnitsPerEm();
         String panose = font.getOS2Table().getPanose().toString();
@@ -273,7 +273,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
      */
     protected static void writeFontAsSVGFragment(PrintStream ps, Font font, String id, int first, int last, boolean autoRange, boolean forceAscii)
     throws Exception {
-        //    StringBuffer sb = new StringBuffer();
+        //    StringBuilder sb = new StringBuilder();
         //    int horiz_advance_x = font.getHmtxTable().getAdvanceWidth(
         //      font.getHheaTable().getNumberOfHMetrics() - 1);
         int horiz_advance_x = font.getOS2Table().getAvgCharWidth();
@@ -427,7 +427,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
             String attrib,
             String code) {
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int firstIndex = 0;
         int count = 0;
         int i;
@@ -486,7 +486,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
         // sb.append("/>");
 
         // Chop-up the string into 255 character lines
-        chopUpStringBuffer(sb);
+        chopUpStringBuilder(sb);
 
         return sb.toString();
     }
@@ -501,7 +501,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
             SingleSubst arabTermSubst,
             String code) {
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         boolean substituted = false;
 
         // arabic = "initial | medial | terminal | isolated"
@@ -590,7 +590,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
         String leftGlyphName = post.getGlyphName(kp.getLeft());
         String rightGlyphName = post.getGlyphName(kp.getRight());
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         // sb.append("<hkern ");
         sb.append(XML_OPEN_TAG_START).append(SVG_HKERN_TAG).append(XML_SPACE);
 
@@ -632,7 +632,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
     }
 /*
     protected static String getGlyphAsPath(Glyph glyph) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int firstIndex = 0;
         int count = 0;
         int i;
@@ -782,7 +782,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
         }
     }
 
-    private static void chopUpStringBuffer(StringBuffer sb) {
+    private static void chopUpStringBuilder(StringBuilder sb) {
         if (sb.length() < 256) {
             return;
         } else {
@@ -802,7 +802,7 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
     }
 
     /*private static String translateSVG(int x, int y, String svgText) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("<g transform=\"translate(")
             .append(String.valueOf(x))
             .append(" ")

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapFormat.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapFormat.java
@@ -69,7 +69,7 @@ public abstract class CmapFormat {
     public abstract int getLast();
 
     public String toString() {
-        return new StringBuffer()
+        return new StringBuilder()
         .append("format: ")
         .append(format)
         .append(", length: ")

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapFormat4.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapFormat4.java
@@ -122,7 +122,7 @@ public class CmapFormat4 extends CmapFormat {
     }
 
     public String toString() {
-        return new StringBuffer( 80 )
+        return new StringBuilder( 80 )
         .append(super.toString())
         .append(", segCountX2: ")
         .append(segCountX2)
@@ -151,7 +151,7 @@ public class CmapFormat4 extends CmapFormat {
      */
     private static String intToStr( int[] array ){
         int nSlots = array.length;
-        StringBuffer workBuff = new StringBuffer( nSlots * 8 );
+        StringBuilder workBuff = new StringBuilder( nSlots * 8 );
         workBuff.append( '[' );
         for( int i= 0; i < nSlots; i++ ){
             workBuff.append( array[ i ] );

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapIndexEntry.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapIndexEntry.java
@@ -71,7 +71,7 @@ public class CmapIndexEntry {
                 default: encoding = "";
             }
         }
-        return new StringBuffer()
+        return new StringBuilder()
         .append( "platform id: " )
         .append( platformId )
         .append( platform )

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapTable.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/CmapTable.java
@@ -70,7 +70,7 @@ public class CmapTable implements Table {
     }
 
     public String toString() {
-        StringBuffer sb = new StringBuffer( numTables * 8 ).append("cmap\n");
+        StringBuilder sb = new StringBuilder( numTables * 8 ).append("cmap\n");
 
         // Get each of the index entries
         for (int i = 0; i < numTables; i++) {

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/DirectoryEntry.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/DirectoryEntry.java
@@ -57,7 +57,7 @@ public class DirectoryEntry {
     }
 
     public String toString() {
-        return new StringBuffer()
+        return new StringBuilder()
             .append((char)((tag>>24)&0xff))
             .append((char)((tag>>16)&0xff))
             .append((char)((tag>>8)&0xff))

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/HeadTable.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/HeadTable.java
@@ -135,7 +135,7 @@ public class HeadTable implements Table {
     }
 
     public String toString() {
-        return new StringBuffer()
+        return new StringBuilder()
             .append("head\n\tversionNumber: ").append(versionNumber)
             .append("\n\tfontRevision: ").append(fontRevision)
             .append("\n\tcheckSumAdjustment: ").append(checkSumAdjustment)

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/NameRecord.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/NameRecord.java
@@ -65,7 +65,7 @@ public class NameRecord {
     }
 
     protected void loadString(RandomAccessFile raf, int stringStorageOffset) throws IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         raf.seek(stringStorageOffset + stringOffset);
         if (platformId == Table.platformAppleUnicode) {
             

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/Panose.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/table/Panose.java
@@ -90,7 +90,7 @@ public class Panose {
   }
   
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append(String.valueOf(bFamilyType)).append(" ")
       .append(String.valueOf(bSerifStyle)).append(" ")
       .append(String.valueOf(bWeight)).append(" ")

--- a/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/Main.java
+++ b/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/Main.java
@@ -964,7 +964,7 @@ public class Main implements SVGConverterController {
     }
 
     protected String toString( String[] v){
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int n = v != null ? v.length:0;
         for (int i=0; i<n; i++){
             sb.append(v[i] );

--- a/batik-swing/src/main/java/org/apache/batik/swing/JSVGCanvas.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/JSVGCanvas.java
@@ -996,7 +996,7 @@ public class JSVGCanvas extends JSVGComponent {
          * Poor way of replacing '&lt;', '&gt;' and '&amp;' in content.
          */
         public String toFormattedHTML(String str) {
-            StringBuffer sb = new StringBuffer(str);
+            StringBuilder sb = new StringBuilder(str);
             replace(sb, XML_CHAR_AMP, XML_ENTITY_AMP);  // Must go first!
             replace(sb, XML_CHAR_LT, XML_ENTITY_LT);
             replace(sb, XML_CHAR_GT, XML_ENTITY_GT);
@@ -1008,7 +1008,7 @@ public class JSVGCanvas extends JSVGComponent {
             return sb.toString();
         }
 
-        protected void replace(StringBuffer sb, char c, String r) {
+        protected void replace(StringBuilder sb, char c, String r) {
             String v = sb.toString();
             int i = v.length();
 

--- a/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
@@ -546,7 +546,7 @@ abstract class AbstractConfigTest extends AbstractTest implements SVGConverterCo
 
     protected String makeSourceList(List v){
         int n = v.size();
-        StringBuffer sb = new StringBuffer( n * 8 );
+        StringBuilder sb = new StringBuilder( n * 8 );
         for (Object aV : v) {
             sb.append(aV.toString());
         }
@@ -556,7 +556,7 @@ abstract class AbstractConfigTest extends AbstractTest implements SVGConverterCo
 
     protected String makeHintsString( Map map){
         Iterator iter = map.keySet().iterator();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (iter.hasNext()){
             Object key = iter.next();
             sb.append(key.toString());

--- a/batik-test-old/src/test/java/org/apache/batik/parser/LengthParserTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/parser/LengthParserTest.java
@@ -33,7 +33,7 @@ public class LengthParserTest extends AbstractTest {
     protected String sourceLength;
     protected String destinationLength;
 
-    protected StringBuffer buffer;
+    protected StringBuilder buffer;
     protected String resultLength;
 
     /**
@@ -76,7 +76,7 @@ public class LengthParserTest extends AbstractTest {
         public TestHandler() {}
 
         public void startLength() throws ParseException {
-            buffer = new StringBuffer();
+            buffer = new StringBuilder();
         }
         
         public void lengthValue(float v) throws ParseException {

--- a/batik-test-old/src/test/java/org/apache/batik/parser/PathParserTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/parser/PathParserTest.java
@@ -33,7 +33,7 @@ public class PathParserTest extends AbstractTest {
     protected String sourcePath;
     protected String destinationPath;
 
-    protected StringBuffer buffer;
+    protected StringBuilder buffer;
     protected String resultPath;
 
     /**
@@ -76,7 +76,7 @@ public class PathParserTest extends AbstractTest {
         public TestHandler() {}
 
         public void startPath() throws ParseException {
-            buffer = new StringBuffer();
+            buffer = new StringBuilder();
         }
         
         public void movetoRel(float x, float y) throws ParseException {

--- a/batik-test-old/src/test/java/org/apache/batik/parser/TransformListParserTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/parser/TransformListParserTest.java
@@ -34,7 +34,7 @@ public class TransformListParserTest extends AbstractTest {
     protected String sourceTransform;
     protected String destinationTransform;
 
-    protected StringBuffer buffer;
+    protected StringBuilder buffer;
     protected String resultTransform;
 
     /**
@@ -77,7 +77,7 @@ public class TransformListParserTest extends AbstractTest {
         boolean first;
         public TestHandler() {}
         public void startTransformList() throws ParseException {
-            buffer = new StringBuffer();
+            buffer = new StringBuilder();
             first = true;
         }
         public void matrix(float a, float b, float c, float d, float e, float f)

--- a/batik-test-old/src/test/java/org/apache/batik/test/MemoryLeakTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/test/MemoryLeakTest.java
@@ -113,7 +113,7 @@ public abstract class MemoryLeakTest  extends AbstractTest {
         for (int i=0; i<NUM_GC; i++)
             rt.gc();
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         boolean passed = true;
         synchronized (objs) {
             for (String desc : descs) {
@@ -187,7 +187,7 @@ public abstract class MemoryLeakTest  extends AbstractTest {
             rt.gc();
 
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         synchronized (objs) {
             boolean passed = true;
             for (Object o1 : objs.values()) {

--- a/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestReportProcessor.java
+++ b/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestReportProcessor.java
@@ -605,7 +605,7 @@ public class XMLTestReportProcessor
      * in attribute values.
      */
     protected String encode(String attrValue){
-        StringBuffer sb = new StringBuffer(attrValue);
+        StringBuilder sb = new StringBuilder(attrValue);
         replace(sb, XML_CHAR_AMP, XML_ENTITY_AMP);
         replace(sb, XML_CHAR_LT, XML_ENTITY_LT);
         replace(sb, XML_CHAR_GT, XML_ENTITY_GT);
@@ -614,7 +614,7 @@ public class XMLTestReportProcessor
         return sb.toString();
     }
 
-    protected void replace(StringBuffer s,
+    protected void replace(StringBuilder s,
                              char c,
                              String r){
         String v = s.toString() + 1;

--- a/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestSuiteRunner.java
+++ b/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestSuiteRunner.java
@@ -134,9 +134,9 @@ public class XMLTestSuiteRunner implements XTRunConstants, XTSConstants{
 
         public String traceUnusedIds(){
             Object[] ui = unmatchedIds.toArray();
-            StringBuffer sb = null;
+            StringBuilder sb = null;
             if(ui != null && ui.length > 0){
-                sb = new StringBuffer();
+                sb = new StringBuilder();
                 sb.append(ui[0].toString());
                 for(int i=1; i<ui.length; i++){
                     sb.append(", ");

--- a/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestSuiteRunnerValidator.java
+++ b/batik-test/src/main/java/org/apache/batik/test/xml/XMLTestSuiteRunnerValidator.java
@@ -246,7 +246,7 @@ public class XMLTestSuiteRunnerValidator extends DefaultTestSuite {
         }
 
         protected String arrayToString(Object[] array){
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             if(array != null){
                 if(array.length > 0){
                     sb.append(array[0]);
@@ -260,7 +260,7 @@ public class XMLTestSuiteRunnerValidator extends DefaultTestSuite {
         }
 
         protected String reportIdsToString(TestReport r){
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             if(r != null){
                 sb.append(r.getTest().getQualifiedId());
                 if(r instanceof TestSuiteReport){
@@ -279,7 +279,7 @@ public class XMLTestSuiteRunnerValidator extends DefaultTestSuite {
             return sb.toString();
         }
 
-        protected void appendReportIds(TestReport r, StringBuffer sb){
+        protected void appendReportIds(TestReport r, StringBuilder sb){
             if(r != null){
                 sb.append(", ");
                 sb.append(r.getTest().getQualifiedId());

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/OutputManager.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/OutputManager.java
@@ -52,7 +52,7 @@ public class OutputManager {
     /**
      * The margin.
      */
-    protected StringBuffer margin = new StringBuffer();
+    protected StringBuilder margin = new StringBuilder();
 
     /**
      * The current line.
@@ -762,7 +762,7 @@ public class OutputManager {
                 startsWithSpace = true;
                 i++;
             }
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (;;) {
                 if (i >= text.length || XMLUtilities.isXMLSpace(text[i])) {
                     break;

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/PrettyPrinter.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/PrettyPrinter.java
@@ -866,7 +866,7 @@ public class PrettyPrinter {
                 char valueDelim = scanner.getStringDelimiter();
                 boolean hasEntityRef = false;
 
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append(getCurrentValue());
                 loop: for (;;) {
                     scanner.clearBuffer();

--- a/batik-util/src/main/java/org/apache/batik/util/ClassFileUtilities.java
+++ b/batik-util/src/main/java/org/apache/batik/util/ClassFileUtilities.java
@@ -413,7 +413,7 @@ public class ClassFileUtilities {
 
                 case 'L':
                     c = desc.charAt(++i);
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     while (c != ';') {
                         sb.append(c);
                         c = desc.charAt(++i);
@@ -440,7 +440,7 @@ public class ClassFileUtilities {
 
             case 'L':
                 c = desc.charAt(++i);
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 while (c != ';') {
                     sb.append(c);
                     c = desc.charAt(++i);
@@ -463,7 +463,7 @@ public class ClassFileUtilities {
 
         case 'L':
             c = desc.charAt(++i);
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             while (c != ';') {
                 sb.append(c);
                 c = desc.charAt(++i);

--- a/batik-util/src/main/java/org/apache/batik/util/ParsedURLDefaultProtocolHandler.java
+++ b/batik-util/src/main/java/org/apache/batik/util/ParsedURLDefaultProtocolHandler.java
@@ -195,7 +195,7 @@ public class ParsedURLDefaultProtocolHandler
         if (idx == -1) return str; // quick out..
 
         int prev=0;
-        StringBuffer ret = new StringBuffer();
+        StringBuilder ret = new StringBuilder();
         while (idx != -1) {
             if (idx != prev)
                 ret.append(str.substring(prev, idx));

--- a/batik-util/src/test/java/org/apache/batik/util/ParsedURLDataTest.java
+++ b/batik-util/src/test/java/org/apache/batik/util/ParsedURLDataTest.java
@@ -110,7 +110,7 @@ public class ParsedURLDataTest extends AbstractTest {
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i=0; i<num; i++) {
             int val = data[i] &0xFF;
             if (val < 16) {

--- a/batik-xml/src/main/java/org/apache/batik/xml/XMLUtilities.java
+++ b/batik-xml/src/main/java/org/apache/batik/xml/XMLUtilities.java
@@ -379,7 +379,7 @@ public class XMLUtilities extends XMLCharacters {
         }
         sc = (char)c;
 
-        StringBuffer enc = new StringBuffer();
+        StringBuilder enc = new StringBuilder();
         for (;;) {
             c = r.read();
             if (c == -1) {


### PR DESCRIPTION
Years ago was in our company made some internal fork based on Batik 1.8. We want switch back to OSS official version. It was back-ported some changes from newers Batik to our 1.8 to be able use JDK9+ but from overall we want use official OSS in future.
As original developer isn't in our company some years we don't know what all was done. He committed state after changes not the original state at first:( We know only that we had performance and memory problems.

We tried to compare official 1.8 with our 1.8. 

One probably usefull change was this migration from StringBuffer to StringBuilder.