### PR TITLE
BATIK-1318: NullPointerException in SAXSVGDocumentFactory.resolveEntity()

### DIFF
--- a/batik-anim/src/main/resources/org/apache/batik/anim/dom/resources/dtdids.properties
+++ b/batik-anim/src/main/resources/org/apache/batik/anim/dom/resources/dtdids.properties
@@ -32,16 +32,16 @@ publicIds = \
     -//W3C//DTD SVG 1.1 Tiny//EN\
     -//W3C//DTD SVG 1.2//EN
 
-systemId.-//W3C//DTD_SVG_1.0//EN = resources/svg10.dtd
-systemId.-//W3C//DTD_SVG_20010904//EN = resources/svg10.dtd
-systemId.-//W3C//DTD_SVG_20001102//EN = resources/svg10.dtd
-systemId.-//W3C//DTD_SVG_20000802//EN = resources/svg10.dtd
-systemId.-//W3C//DTD_SVG_20000303_Stylable//EN = resources/svg10.dtd
+systemId.-//W3C//DTD_SVG_1.0//EN = /org/apache/batik/dom/svg/resources/svg10.dtd
+systemId.-//W3C//DTD_SVG_20010904//EN = /org/apache/batik/dom/svg/resources/svg10.dtd
+systemId.-//W3C//DTD_SVG_20001102//EN = /org/apache/batik/dom/svg/resources/svg10.dtd
+systemId.-//W3C//DTD_SVG_20000802//EN = /org/apache/batik/dom/svg/resources/svg10.dtd
+systemId.-//W3C//DTD_SVG_20000303_Stylable//EN = /org/apache/batik/dom/svg/resources/svg10.dtd
 
-systemId.-//W3C//DTD_SVG_1.1//EN = resources/svg11-flat.dtd
-systemId.-//W3C//DTD_SVG_1.1_Basic//EN = resources/svg11-basic-flat.dtd
-systemId.-//W3C//DTD_SVG_1.1_Tiny//EN = resources/svg11-tiny-flat.dtd
-systemId.-//W3C//DTD_SVG_1.2//EN = resources/svg12-flat.dtd
+systemId.-//W3C//DTD_SVG_1.1//EN = /org/apache/batik/dom/svg/resources/svg11-flat.dtd
+systemId.-//W3C//DTD_SVG_1.1_Basic//EN = /org/apache/batik/dom/svg/resources/svg11-basic-flat.dtd
+systemId.-//W3C//DTD_SVG_1.1_Tiny//EN = /org/apache/batik/dom/svg/resources/svg11-tiny-flat.dtd
+systemId.-//W3C//DTD_SVG_1.2//EN = /org/apache/batik/dom/svg/resources/svg12-flat.dtd
 
 #
 # The skippablePublicIds property represents the list of SVG DTD's we


### PR DESCRIPTION
Suggested fix for [BATIK-1318].

In 2014 the `SAXSVGDocumentFactory` class along with the `dtdids.properties` resource have been moved from `org.apache.batik.dom.svg` to `org.apache.batik.anim.dom` package:

-   412c7bb1ede09d81e9a2125542439a762ba1c501  removed cyclic dependencies reported in [BATIK-1098]

However, the resources referenced in `dtdids.properties` are still in `org.apache.batik.dom.svg` package:

-   [batik-svg-dom/src/main/resources/org/apache/batik/dom/svg/resources/](https://github.com/apache/xmlgraphics-batik/tree/42f696530256dd1bfeec4870922c208d67c0c128/batik-svg-dom/src/main/resources/org/apache/batik/dom/svg/resources)

This makes the following `Class.getResource()` return `null` and ultimately cause NPE:

https://github.com/apache/xmlgraphics-batik/blob/42f696530256dd1bfeec4870922c208d67c0c128/batik-anim/src/main/java/org/apache/batik/anim/dom/SAXSVGDocumentFactory.java#L386-L392

I can see the overall issue has been partially addressed in f2dac46c5e23f830321829eda248fecafce443f9.  I suggest further the `dtdids.properties` should be updated with absolute resource names.

[BATIK-1098]: https://issues.apache.org/jira/browse/BATIK-1098 "Circular dependencies between submodules"
[BATIK-1318]: https://issues.apache.org/jira/browse/BATIK-1318 "rasterizer validate throws NPE"
