### PR TITLE
[BATIK-1362] add Automatic-Module-Name to jar manifest during build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,17 +11,22 @@ on:
 
 jobs:
   build:
-
+    name: Test with Java ${{ matrix.jdk }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ '8', '11', '17', '21' ]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 8
+    - uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.jdk }}
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: ${{ matrix.jdk }}
         distribution: 'temurin'
         cache: maven
+
     - name: Build with Maven
       run: mvn -B package checkstyle:check --file pom.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 .settings
 target
+.idea/
+*.iml

--- a/batik-anim/pom.xml
+++ b/batik-anim/pom.xml
@@ -85,6 +85,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.anim</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-awt-util/pom.xml
+++ b/batik-awt-util/pom.xml
@@ -55,6 +55,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.awt.util</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-bridge/pom.xml
+++ b/batik-bridge/pom.xml
@@ -111,6 +111,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.brdige</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-codec/pom.xml
+++ b/batik-codec/pom.xml
@@ -65,6 +65,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.codec</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-constants/pom.xml
+++ b/batik-constants/pom.xml
@@ -45,6 +45,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.constants</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-css/pom.xml
+++ b/batik-css/pom.xml
@@ -60,6 +60,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.css</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-dom/pom.xml
+++ b/batik-dom/pom.xml
@@ -75,6 +75,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.dom</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-ext/pom.xml
+++ b/batik-ext/pom.xml
@@ -45,6 +45,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.ext</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-extension/pom.xml
+++ b/batik-extension/pom.xml
@@ -100,6 +100,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.extension</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-gvt/pom.xml
+++ b/batik-gvt/pom.xml
@@ -55,6 +55,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.gvt</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-i18n/pom.xml
+++ b/batik-i18n/pom.xml
@@ -45,6 +45,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.i18n</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-parser/pom.xml
+++ b/batik-parser/pom.xml
@@ -65,6 +65,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.parser</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-rasterizer/pom.xml
+++ b/batik-rasterizer/pom.xml
@@ -50,6 +50,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -60,12 +61,14 @@
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
             <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.rasterizer</Automatic-Module-Name>
               <Class-Path>lib/fop-transcoder-allinone-${xmlgraphics.commons.version}.jar</Class-Path>
             </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-script/pom.xml
+++ b/batik-script/pom.xml
@@ -67,6 +67,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler.version}</version><!--$NO-MVN-MAN-VER$-->
         <configuration>
@@ -76,6 +77,19 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.script</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-slideshow/pom.xml
+++ b/batik-slideshow/pom.xml
@@ -60,6 +60,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -69,10 +70,14 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.slideshow</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-squiggle-ext/pom.xml
+++ b/batik-squiggle-ext/pom.xml
@@ -55,6 +55,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -63,10 +64,14 @@
               <mainClass>org.apache.batik.apps.svgbrowser.Main</mainClass>
               <addClasspath>true</addClasspath>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.squiggleext</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-squiggle/pom.xml
+++ b/batik-squiggle/pom.xml
@@ -50,6 +50,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -59,10 +60,14 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.squiggle</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-svg-dom/pom.xml
+++ b/batik-svg-dom/pom.xml
@@ -80,6 +80,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.svgdom</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-svgbrowser/pom.xml
+++ b/batik-svgbrowser/pom.xml
@@ -90,6 +90,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.svgbrowser</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-svggen/pom.xml
+++ b/batik-svggen/pom.xml
@@ -55,6 +55,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.svggen</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-svgpp/pom.xml
+++ b/batik-svgpp/pom.xml
@@ -55,6 +55,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -64,10 +65,14 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.svgpp</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-svgrasterizer/pom.xml
+++ b/batik-svgrasterizer/pom.xml
@@ -65,6 +65,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.svgrasterizer</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-swing/pom.xml
+++ b/batik-swing/pom.xml
@@ -100,6 +100,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.swing</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-transcoder/pom.xml
+++ b/batik-transcoder/pom.xml
@@ -90,6 +90,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.transcoder</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->
         <executions>

--- a/batik-ttf2svg/pom.xml
+++ b/batik-ttf2svg/pom.xml
@@ -50,6 +50,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${jar.version}</version>
         <configuration>
@@ -59,6 +60,17 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.ttf2svg</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/batik-util/pom.xml
+++ b/batik-util/pom.xml
@@ -77,18 +77,25 @@
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-jar-plugin</artifactId>
-         <version>${jar.version}</version>
-         <executions>
-           <execution>
-             <goals>
-               <goal>test-jar</goal>
-             </goals>
-           </execution>
-         </executions>
-       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${jar.version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.util</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${dependency.version}</version><!--$NO-MVN-MAN-VER$-->

--- a/batik-xml/pom.xml
+++ b/batik-xml/pom.xml
@@ -68,6 +68,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.xmlgraphics.batik.xml</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,23 +13,25 @@
   <inceptionYear>2000</inceptionYear>
 
   <properties>
-    <checkstyle.version>2.15</checkstyle.version>
-    <compiler.version>3.3</compiler.version>
-    <dependency.version>3.1.1</dependency.version>
-    <findbugs.version>3.0.1</findbugs.version>
-    <jar.version>3.1.1</jar.version>
+    <checkstyle.version>3.3.1</checkstyle.version>
+    <compiler.version>3.11.0</compiler.version>
+    <dependency.version>3.6.1</dependency.version>
+    <findbugs.version>3.0.4</findbugs.version>
+    <jar.version>3.3.0</jar.version>
     <java.version>1.8</java.version>
-    <junit.version>4.11</junit.version>
-    <jython.version>2.7.0</jython.version>
+    <junit.version>4.13.2</junit.version>
+<!--    <junit4.version>4.13.2</junit4.version>-->
+    <junit5.version>5.10.1</junit5.version>
+    <jython.version>2.7.3</jython.version>
     <org.slf4j.simpleLogger.defaultLogLevel>error</org.slf4j.simpleLogger.defaultLogLevel>
-    <project.info.reports.version>2.8</project.info.reports.version>
+    <project.info.reports.version>3.4.5</project.info.reports.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <release.version>2.5.2</release.version>
-    <rhino.version>1.7.7</rhino.version>
-    <surefire.version>2.18.1</surefire.version>
+    <release.version>3.0.1</release.version>
+    <rhino.version>1.7.14</rhino.version>
+    <surefire.version>3.2.2</surefire.version>
     <xmlapis.version>1.4.01</xmlapis.version>
     <xmlapisext.version>1.3.04</xmlapisext.version>
-    <xmlgraphics.commons.version>2.7</xmlgraphics.commons.version>
+    <xmlgraphics.commons.version>2.9</xmlgraphics.commons.version>
     <jdk.path>${env.JAVA_HOME}</jdk.path>
   </properties>
 
@@ -64,8 +66,13 @@
 
   <organization>
     <name>Apache Software Foundation</name>
-    <url>http://www.apache.org/</url>
+    <url>https://www.apache.org/</url>
   </organization>
+
+  <issueManagement>
+    <system>Jira</system>
+    <url>https://issues.apache.org/jira/browse/BATIK</url>
+  </issueManagement>
 
   <modules>
     <module>batik-all</module>
@@ -121,6 +128,16 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${jar.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>${project.info.reports.version}</version>
         </plugin>
@@ -147,6 +164,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.6.2</version>
           <configuration>
             <source>8</source>
             <doclint>none</doclint>


### PR DESCRIPTION
as per option 3 in https://issues.apache.org/jira/browse/BATIK-1362 this PR uses maven-jar-plugin to add Automatic-Module-Name to the manifest during build