### PR TITLE
BATIK-1102 - avoid dividing by zero when processing particular feTurbulence seed values

### DIFF
--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/TurbulencePatternRed.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/TurbulencePatternRed.java
@@ -263,8 +263,10 @@ public final class TurbulencePatternRed extends AbstractRed {
 
         for(k = 0; k < 4; k++){
             for(i = 0; i < BSize; i++){
-                u = (((seed = random(seed)) % (BSize + BSize)) - BSize);
-                v = (((seed = random(seed)) % (BSize + BSize)) - BSize);
+                do{
+                    u = (((seed = random(seed)) % (BSize + BSize)) - BSize);
+                    v = (((seed = random(seed)) % (BSize + BSize)) - BSize);
+                }while(u == 0 && v == 0);
 
                 s = 1/Math.sqrt(u*u + v*v);
                 gradient[i*8 + k*2    ] = u*s;


### PR DESCRIPTION
See http://lists.w3.org/Archives/Public/www-svg/2015Jan/0005.html and http://lists.w3.org/Archives/Public/www-svg/2015Jan/0014.html and http://jsfiddle.net/dodgeyhack/mo7x85zw/