### PR TITLE
BATIK-1225: Fix imageio codec lookup

### DIFF
--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
@@ -116,7 +116,7 @@ public class PNGTranscoder extends ImageTranscoder {
                 "org.apache.batik.ext.awt.image.codec.png.PNGTranscoderInternalCodecWriteAdapter");
         if (adapter == null) {
             adapter = getWriteAdapter(
-                "org.apache.batik.transcoder.image.PNGTranscoderImageIOWriteAdapter");
+                "org.apache.batik.ext.awt.image.codec.imageio.PNGTranscoderImageIOWriteAdapter");
         }
         if (adapter == null) {
             throw new TranscoderException(


### PR DESCRIPTION
Fedora has been carrying this as a downstream patch since 2015. It was reported in the Batik JIRA, but AFAICT a patch was never submitted.

In practice it doesn't seem to affect anything, because `PNGTranscoderInternalCodecWriteAdapter` is always available. But if for some reason it wasn't, the code would fail attempting to look up the wrong fallback class.