### PR TITLE
BATIK-1370: display:none on referenced elements

### DIFF
--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGUseElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGUseElementBridge.java
@@ -217,7 +217,8 @@ public class SVGUseElementBridge extends AbstractGraphicsNodeBridge {
 
         ///////////////////////////////////////////////////////////////////////
 
-        gn.getChildren().add(refNode);
+        if (refNode != null)
+            gn.getChildren().add(refNode);
 
         gn.setTransform(computeTransform((SVGTransformable) e, ctx));
 


### PR DESCRIPTION
[display:none on referenced elements causes java.lang.IllegalArgumentException](https://issues.apache.org/jira/browse/BATIK-1370)