### PR TITLE
BATIK-1366: add read and connection timeout on ParsedURLData

### DIFF
--- a/batik-util/pom.xml
+++ b/batik-util/pom.xml
@@ -62,6 +62,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/batik-util/src/main/java/org/apache/batik/util/ParsedURLData.java
+++ b/batik-util/src/main/java/org/apache/batik/util/ParsedURLData.java
@@ -45,6 +45,8 @@ public class ParsedURLData {
     protected static final String HTTP_ACCEPT_HEADER          = "Accept";
     protected static final String HTTP_ACCEPT_LANGUAGE_HEADER = "Accept-Language";
     protected static final String HTTP_ACCEPT_ENCODING_HEADER = "Accept-Encoding";
+    protected static final int CONNECT_TIMEOUT = 5000;
+    protected static final int READ_TIMEOUT = 20000;
 
     protected static List acceptedEncodings = new LinkedList();
     static {
@@ -543,6 +545,8 @@ loop2:          while (i < len) {
                 }
                 urlC.setRequestProperty(HTTP_ACCEPT_ENCODING_HEADER,
                                         encodingHeader);
+                urlC.setConnectTimeout(CONNECT_TIMEOUT);
+                urlC.setReadTimeout(READ_TIMEOUT);
             }
 
             contentType       = urlC.getContentType();

--- a/batik-util/src/test/java/org/apache/batik/util/ParsedURLDataTimeoutUnitTest.java
+++ b/batik-util/src/test/java/org/apache/batik/util/ParsedURLDataTimeoutUnitTest.java
@@ -1,0 +1,50 @@
+package org.apache.batik.util;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+
+public class ParsedURLDataTimeoutUnitTest {
+
+    private MockWebServer _mockWebServer;
+
+    @Before
+    public void setUp() throws IOException {
+        _mockWebServer = new MockWebServer();
+        _mockWebServer.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        _mockWebServer.shutdown();
+    }
+
+    /**
+     * Test that a SocketTimeoutException is thrown when the server does not respond.
+     * This test fails in case URLConnection in ParsedURLData has no timeout set.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testThatTimeoutIsUsedForURLConnection() throws Exception {
+        _mockWebServer.enqueue(new MockResponse()
+                .setSocketPolicy(SocketPolicy.NO_RESPONSE));
+        ParsedURLData data = new ParsedURLData(_mockWebServer.url("/test").url());
+        List<String> mimeTypes = new ArrayList<>();
+        mimeTypes.add("text/html");
+        assertThrows(SocketTimeoutException.class, () -> {
+            InputStream userAgent = data.openStream("userAgent", mimeTypes.iterator());
+        });
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BATIK-1366

Introduces timeouts on http requests in ParsedUrlData.