### PR TITLE
BATIK-1375. Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,9 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
   </repositories>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Build](https://github.com/apache/xmlgraphics-batik/actions/runs/11720804128/job/32646913083#step:4:1378) tries to download release artifacts from Apache snapshots repo:

```
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/python/jython/2.7.0/jython-2.7.0.pom
Downloading from central: https://repo.maven.apache.org/maven2/org/python/jython/2.7.0/jython-2.7.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/python/jython/2.7.0/jython-2.7.0.pom (1.4 kB at 102 kB/s)
```

The Apache snapshot repository should be enabled only for snapshots.

> `enabled`: `true` or `false` for whether this repository is enabled for the respective type (`releases` or `snapshots`). By default this is `true`.  ([source](https://maven.apache.org/pom.html#Repositories))

https://issues.apache.org/jira/browse/BATIK-1375

## How was this patch tested?

Local build.

Repo list:

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ batik ---
[INFO] Remote repositories used by project org.apache.xmlgraphics:batik:pom:1.18.0-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, default, snapshots)
[INFO]    First introduced on root
```