### PR TITLE
BATIK-1378 Add support for selective glyph extraction

### DIFF
--- a/batik-svggen/src/main/java/org/apache/batik/svggen/font/SVGFont.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/font/SVGFont.java
@@ -317,8 +317,44 @@ public class SVGFont implements XMLConstants, SVGConstants, ScriptTags, FeatureT
 
             try {
                 Scanner intList = new Scanner(new File(fileName));
-                while (intList.hasNextInt()) {
-                    requiredGlyphIndexes.add(intList.nextInt());
+                while (intList.hasNext()) {
+                    String s = intList.next();
+
+                    if (s.length() > 0) {
+                        int radix, p0, v;
+                        boolean intParsingDone = false;
+                        char[] cl = s.toCharArray();
+
+                        if (cl[0] == '0' && (cl[1] == 'x' || cl[1] == 'X')) {
+                            radix = 16;
+                            p0 = 2;
+                        } else {
+                            radix = 10;
+                            p0 = 0;
+                        }
+                        v = 0;
+                        for (int i = p0; i < cl.length; i++) {
+                            char c = cl[i];
+                            if (c >= 'A' && c <= 'F')
+                                v = v * radix + c - 'A' + 10;
+                            else if (c >= 'a' && c <= 'f')
+                                v = v * radix + c - 'a' + 10;
+                            else if (c >= '0' && c <= '9')
+                                v = v * radix + c - '0';
+                            else
+                                break;
+                            intParsingDone = true;
+                        }
+                        cl = null;
+
+                        if (intParsingDone == false) {
+                            System.err.printf("WARNING: Not-parsed string [%s]\n", s);
+                        } else if (requiredGlyphIndexes.contains(v) == false) {
+                            requiredGlyphIndexes.add(v);
+                        } else {
+                            System.err.printf("WARNING: Duplicate string [%s]\n", s);
+                        }
+                    }
                 }
                 intList.close();
             } catch (FileNotFoundException e) {

--- a/batik-svggen/src/main/resources/org/apache/batik/svggen/font/resources/Messages.properties
+++ b/batik-svggen/src/main/resources/org/apache/batik/svggen/font/resources/Messages.properties
@@ -19,7 +19,7 @@
 # -----------------------------------------------------------------------------
 
 SVGFont.config.usage = \
-usage: java org.apache.batik.svggen.font.SVGFont <ttf-path> [-l <range-begin>] [-h <range-end>] [-autorange] [-ascii] [-id <id>] [-o <output-path>] [-testcard]
+usage: java org.apache.batik.svggen.font.SVGFont <ttf-path> [-l <range-begin>] [-h <range-end>] [-autorange] [-ascii] [-id <id>] [-o <output-path>] [-testcard] [-u <unicode-list-file>]
 
 SVGFont.config.svg.begin = \
 <?xml version="1.0" standalone="no"?> \

--- a/build.xml
+++ b/build.xml
@@ -1350,7 +1350,11 @@ JAVA=/usr/bin/java
         <path refid="libs-classpath"/>
         <pathelement location="resources"/>
       </classpath>
-      <arg line="${args}"/>
+      <arg line="/usr/share/fonts/truetype/liberation2/LiberationMono-Regular.ttf"/>
+      <arg line="-u"/>
+      <arg line="list-h.txt"/>
+      <arg line="-o"/>
+      <arg line="out3.svg"/>
     </java>
   </target>
 


### PR DESCRIPTION
Fixes BATIK-1378

Present ttf2svg application has a limitation that it export all characters or it export range of characters.
Consider a case of Chinese/Japanese language which was resulting in large svg file.
To avoid this we have added an option '-u' to specify a text file with unicode symbols, which are required in svg file.
