### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 .settings
 target
+.idea

--- a/CHANGES
+++ b/CHANGES
@@ -297,7 +297,7 @@ BATIK-1222: Only call DOMImplementation in deserialization
   * Motion animation transforms are now applied after the transform=""
     attribute.
   * Fixed bug in DOM event default action invocation in SVG 1.2 documents.
-  * Fixed bug in CSS class name matching, which occured only when an
+  * Fixed bug in CSS class name matching, which occurred only when an
     element was declared to be a member of multiple classes, where one
     is a prefix of another.
   * Fixed bug on OS X where the zoom interactor overlay was not shown.

--- a/batik-anim/src/main/java/org/apache/batik/anim/dom/SAXSVGDocumentFactory.java
+++ b/batik-anim/src/main/java/org/apache/batik/anim/dom/SAXSVGDocumentFactory.java
@@ -128,7 +128,7 @@ public class SAXSVGDocumentFactory
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param inp The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public SVGDocument createSVGDocument(String uri, InputStream inp)
         throws IOException {
@@ -139,7 +139,7 @@ public class SAXSVGDocumentFactory
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public SVGDocument createSVGDocument(String uri, Reader r)
         throws IOException {
@@ -150,7 +150,7 @@ public class SAXSVGDocumentFactory
      * Creates a SVG Document instance.
      * This method supports gzipped sources.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri) throws IOException {
         ParsedURL purl = new ParsedURL(uri);
@@ -213,7 +213,7 @@ public class SAXSVGDocumentFactory
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param inp The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri, InputStream inp)
         throws IOException {
@@ -242,7 +242,7 @@ public class SAXSVGDocumentFactory
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri, Reader r)
         throws IOException {
@@ -272,7 +272,7 @@ public class SAXSVGDocumentFactory
      * @param ns The namespace URI of the root element of the document.
      * @param root The name of the root element of the document.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri)
         throws IOException {
@@ -289,7 +289,7 @@ public class SAXSVGDocumentFactory
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param is The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri,
                                    InputStream is) throws IOException {
@@ -306,7 +306,7 @@ public class SAXSVGDocumentFactory
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri,
                                    Reader r) throws IOException {

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
@@ -1336,7 +1336,7 @@ public abstract class AbstractGraphics2D extends Graphics2D implements Cloneable
      * <code>Component</code>.  To change the background
      * of the <code>Component</code>, use appropriate methods of
      * the <code>Component</code>.
-     * @param color the background color that isused in
+     * @param color the background color that issued in
      * subsequent calls to <code>clearRect</code>
      * @see #getBackground
      * @see java.awt.Graphics#clearRect

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
@@ -79,7 +79,7 @@ public abstract class AbstractGraphics2D extends Graphics2D implements Cloneable
 
     /**
      * @param textAsShapes if true, all text is turned into shapes in the
-     *        convertion. No text is output.
+     *        conversion. No text is output.
      *
      */
     public AbstractGraphics2D(boolean textAsShapes) {

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/AbstractGraphics2D.java
@@ -978,7 +978,7 @@ public abstract class AbstractGraphics2D extends Graphics2D implements Cloneable
      * @param s the <code>Shape</code> to check for a hit
      * @param onStroke flag used to choose between testing the
      * stroked or the filled shape.  If the flag is <code>true</code>, the
-     * <code>Stroke</code> oultine is tested.  If the flag is
+     * <code>Stroke</code> outline is tested.  If the flag is
      * <code>false</code>, the filled <code>Shape</code> is tested.
      * @return <code>true</code> if there is a hit; <code>false</code>
      * otherwise.

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/GraphicContext.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/g2d/GraphicContext.java
@@ -765,7 +765,7 @@ public class GraphicContext implements Cloneable{
      * <code>Component</code>.  To change the background
      * of the <code>Component</code>, use appropriate methods of
      * the <code>Component</code>.
-     * @param color the background color that isused in
+     * @param color the background color that issued in
      * subsequent calls to <code>clearRect</code>
      * @see #getBackground
      * @see java.awt.Graphics#clearRect

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/renderable/DeferRable.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/renderable/DeferRable.java
@@ -28,7 +28,7 @@ import java.util.Vector;
 
 /**
  * This class allows for the return of a proxy object quickly, while a
- * heavy weight object is constrcuted in a background Thread.  This
+ * heavy weight object is constructed in a background Thread.  This
  * proxy object will then block if any methods are called on it that
  * require talking to the source object.
  *

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/Any2LsRGBRed.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/Any2LsRGBRed.java
@@ -66,7 +66,7 @@ public class Any2LsRGBRed extends AbstractRed {
     }
 
     /**
-     * Gamma for linear to sRGB convertion
+     * Gamma for linear to sRGB conversion
      */
     private static final double GAMMA = 2.4;
     private static final double LFACT = 1.0/12.92;

--- a/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/Any2sRGBRed.java
+++ b/batik-awt-util/src/main/java/org/apache/batik/ext/awt/image/rendered/Any2sRGBRed.java
@@ -86,7 +86,7 @@ public class Any2sRGBRed extends AbstractRed {
    }
 
     /**
-     * Exponent for linear to sRGB convertion
+     * Exponent for linear to sRGB conversion
      */
     private static final double GAMMA = 2.4;
 

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/BridgeException.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/BridgeException.java
@@ -32,7 +32,7 @@ import org.w3c.dom.svg.SVGDocument;
  */
 public class BridgeException extends RuntimeException {
 
-    /** The element on which the error occured. */
+    /** The element on which the error occurred. */
     protected Element e;
 
     /** The error code. */
@@ -46,7 +46,7 @@ public class BridgeException extends RuntimeException {
     /** The paramters to use for the error message. */
     protected Object [] params;
 
-    /** The line number on which the error occured. */
+    /** The line number on which the error occurred. */
     protected int line;
 
     /** The graphics node that represents the current state of the GVT tree. */

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/DocumentLoader.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/DocumentLoader.java
@@ -95,7 +95,7 @@ public class DocumentLoader {
     /**
      * Returns a document from the specified uri.
      * @param uri the uri of the document
-     * @exception IOException if an I/O error occured while loading
+     * @exception IOException if an I/O error occurred while loading
      * the document
      */
     public Document loadDocument(String uri) throws IOException {
@@ -117,7 +117,7 @@ public class DocumentLoader {
     /**
      * Returns a document from the specified uri.
      * @param uri the uri of the document
-     * @exception IOException if an I/O error occured while loading
+     * @exception IOException if an I/O error occurred while loading
      * the document
      */
     public Document loadDocument(String uri, InputStream is)

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/GVTBuilder.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/GVTBuilder.java
@@ -46,7 +46,7 @@ public class GVTBuilder implements SVGConstants {
      *
      * @param ctx the bridge context
      * @param document the SVG document to build
-     * @exception BridgeException if an error occured while constructing
+     * @exception BridgeException if an error occurred while constructing
      * the GVT tree
      */
     public GraphicsNode build(BridgeContext ctx, Document document) {
@@ -112,7 +112,7 @@ public class GVTBuilder implements SVGConstants {
      *
      * @param ctx the bridge context
      * @param e the element to build
-     * @exception BridgeException if an error occured while constructing
+     * @exception BridgeException if an error occurred while constructing
      * the GVT tree
      */
     public GraphicsNode build(BridgeContext ctx, Element e) {
@@ -160,7 +160,7 @@ public class GVTBuilder implements SVGConstants {
      * @param e the element to build
      * @param parentNode the composite graphics node, parent of the
      *                   graphics node to build
-     * @exception BridgeException if an error occured while constructing
+     * @exception BridgeException if an error occurred while constructing
      * the GVT tree
      */
     protected void buildComposite(BridgeContext ctx,
@@ -180,7 +180,7 @@ public class GVTBuilder implements SVGConstants {
      * @param e the element to build
      * @param parentNode the composite graphics node, parent of the
      *                   graphics node to build
-     * @exception BridgeException if an error occured while constructing
+     * @exception BridgeException if an error occurred while constructing
      * the GVT tree
      */
     protected void buildGraphicsNode(BridgeContext ctx,

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/PaintServer.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/PaintServer.java
@@ -322,7 +322,7 @@ public abstract class PaintServer
 
     /**
      * Converts a Paint specified by URI without sending any error.
-     * if a problem occured while processing the URI, it just returns
+     * if a problem occurred while processing the URI, it just returns
      * null (same effect as 'none')
      *
      * @param paintedElement the element interested in a Paint

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGAltGlyphElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGAltGlyphElementBridge.java
@@ -265,7 +265,7 @@ public class SVGAltGlyphElementBridge extends AbstractSVGBridge
             // this is ok, it is possible that the glyph at the given
             // uri is not available. 
 
-            // Display an error message if a security exception occured
+            // Display an error message if a security exception occurred
             if (ERR_URI_UNSECURE.equals(e.getCode())) {
                 ctx.getUserAgent().displayError(e);
             }

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGImageElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGImageElementBridge.java
@@ -722,7 +722,7 @@ public class SVGImageElementBridge extends AbstractGraphicsNodeBridge {
         initializeViewport(ctx, e, result, vb, bounds);
 
         // add a listener on the outermost svg element of the SVG image.
-        // if an event occured inside the SVG image document, send it
+        // if an event occurred inside the SVG image document, send it
         // to the <image> element (inside the original document).
         if (ctx.isInteractive()) {
             listener = new ForwardEventListener(svgElement, e);

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/SVGTextElementBridge.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/SVGTextElementBridge.java
@@ -579,7 +579,7 @@ public class SVGTextElementBridge extends AbstractGraphicsNodeBridge
      * Invoked when an MutationEvent of type 'DOMSubtree' is fired.
      */
     public void handleDOMSubtreeModifiedEvent(MutationEvent evt) {
-        //an operation occured onto the children of the
+        //an operation occurred onto the children of the
         //text element, check if the layout was discarded
         if (laidoutText == null) {
             computeLaidoutText(ctx, e, getTextNode());

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/ViewBox.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/ViewBox.java
@@ -62,7 +62,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
      * @param w the width of the effective viewport
      * @param h The height of the effective viewport
      * @param ctx The BridgeContext to use for error information
-     * @exception BridgeException if an error occured while computing the
+     * @exception BridgeException if an error occurred while computing the
      *            preserveAspectRatio transform
      */
     public static AffineTransform getViewTransform(String ref,
@@ -490,7 +490,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when the fragment identifier starts.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void startFragmentIdentifier() throws ParseException { }
@@ -498,7 +498,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
         /**
          * Invoked when an ID has been parsed.
          * @param s The string that represents the parsed ID.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void idReference(String s) throws ParseException {
@@ -512,7 +512,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
          * @param y the viewbox y coordinate
          * @param width the viewbox width
          * @param height the viewbox height
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void viewBox(float x, float y, float width, float height)
@@ -528,7 +528,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when a view target specification starts.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void startViewTarget() throws ParseException { }
@@ -537,7 +537,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
          * Invoked when a identifier has been parsed within a view target
          * specification.
          * @param name the target name.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void viewTarget(String name) throws ParseException {
@@ -547,7 +547,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when a view target specification ends.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void endViewTarget() throws ParseException { }
@@ -555,7 +555,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
         /**
          * Invoked when a 'zoomAndPan' specification has been parsed.
          * @param magnify true if 'magnify' has been parsed.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void zoomAndPan(boolean magnify) {
@@ -565,7 +565,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when the fragment identifier ends.
-         * @exception ParseException if an error occured while processing the
+         * @exception ParseException if an error occurred while processing the
          *                           fragment identifier
          */
         public void endFragmentIdentifier() throws ParseException { }
@@ -581,14 +581,14 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when the PreserveAspectRatio parsing starts.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void startPreserveAspectRatio() throws ParseException { }
 
         /**
          * Invoked when 'none' been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void none() throws ParseException {
@@ -597,7 +597,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMaxYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMax() throws ParseException {
@@ -606,7 +606,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMaxYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMid() throws ParseException {
@@ -615,7 +615,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMaxYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMin() throws ParseException {
@@ -624,7 +624,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMidYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMax() throws ParseException {
@@ -633,7 +633,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMidYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMid() throws ParseException {
@@ -642,7 +642,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMidYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMin() throws ParseException {
@@ -651,7 +651,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMinYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMax() throws ParseException {
@@ -660,7 +660,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMinYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMid() throws ParseException {
@@ -669,7 +669,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'xMinYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMin() throws ParseException {
@@ -678,7 +678,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'meet' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void meet() throws ParseException {
@@ -687,7 +687,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when 'slice' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void slice() throws ParseException {
@@ -696,7 +696,7 @@ public abstract class ViewBox implements SVGConstants, ErrorConstants {
 
         /**
          * Invoked when the PreserveAspectRatio parsing ends.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void endPreserveAspectRatio() throws ParseException {

--- a/batik-bridge/src/main/resources/org/apache/batik/bridge/resources/Messages.properties
+++ b/batik-bridge/src/main/resources/org/apache/batik/bridge/resources/Messages.properties
@@ -66,13 +66,13 @@ specified on the element <{2}> - may be a problem of ''id''
 
 uri.io = \
 {0}:{1}\n\
-An I/O error occured while processing the URI:\n\
+An I/O error occurred while processing the URI:\n\
 "{3}"\n\
 specified on the element <{2}>
 
 uri.unsecure = \
 {0}:{1}\n\
-A security exception occured while processing the URI:\n\
+A security exception occurred while processing the URI:\n\
 "{3}"\n\
 specified on the element <{2}>
 

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractDOMImplementation.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractDOMImplementation.java
@@ -74,7 +74,7 @@ public abstract class AbstractDOMImplementation
         registerFeature("Traversal",          "2.0");
         registerFeature("XPath",              "3.0");
     }
-    
+
     /**
      * Registers a DOM feature.
      */
@@ -123,7 +123,7 @@ public abstract class AbstractDOMImplementation
     /**
      * <b>DOM</b>: Implements
      * {@link org.w3c.dom.DOMImplementation#getFeature(String,String)}.
-     * No compound document support, so just return this DOMImlpementation
+     * No compound document support, so just return this DOMImplementation
      * where appropriate.
      */
     public Object getFeature(String feature, String version) {

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
@@ -1770,7 +1770,7 @@ public abstract class AbstractDocument
         protected Node relatedNode;
 
         /**
-         * The exception which cuased this error.
+         * The exception which caused this error.
          */
         protected Object relatedException;
 

--- a/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/AbstractDocument.java
@@ -1283,7 +1283,7 @@ public abstract class AbstractDocument
     protected boolean normalizeDocument(Element e,
                                         boolean cdataSections,
                                         boolean comments,
-                                        boolean elementContentWhitepace,
+                                        boolean elementContentWhitespace,
                                         boolean namespaceDeclarations,
                                         boolean namespaces,
                                         boolean splitCdataSections,
@@ -1324,7 +1324,7 @@ public abstract class AbstractDocument
                 } else {
                     n = t;
                 }
-                if (!elementContentWhitepace) {
+                if (!elementContentWhitespace) {
                     // remove element content whitespace text nodes
                     nt = n.getNodeType();
                     if (nt == Node.TEXT_NODE) {
@@ -1611,7 +1611,7 @@ public abstract class AbstractDocument
                     if (!normalizeDocument((Element) m,
                                            cdataSections,
                                            comments,
-                                           elementContentWhitepace,
+                                           elementContentWhitespace,
                                            namespaceDeclarations,
                                            namespaces,
                                            splitCdataSections,

--- a/batik-dom/src/main/java/org/apache/batik/dom/util/DocumentFactory.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/util/DocumentFactory.java
@@ -52,7 +52,7 @@ public interface DocumentFactory {
      * @param ns The namespace URI of the root element of the document.
      * @param root The name of the root element of the document.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     Document createDocument(String ns, String root, String uri) throws IOException;
 
@@ -62,7 +62,7 @@ public interface DocumentFactory {
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param is The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     Document createDocument(String ns, String root, String uri, InputStream is)
         throws IOException;
@@ -73,7 +73,7 @@ public interface DocumentFactory {
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param r An XMLReader instance
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     Document createDocument(String ns, String root, String uri, XMLReader r)
         throws IOException;
@@ -84,7 +84,7 @@ public interface DocumentFactory {
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     Document createDocument(String ns, String root, String uri, Reader r)
         throws IOException;

--- a/batik-dom/src/main/java/org/apache/batik/dom/util/SAXDocumentFactory.java
+++ b/batik-dom/src/main/java/org/apache/batik/dom/util/SAXDocumentFactory.java
@@ -242,7 +242,7 @@ public class SAXDocumentFactory
      * @param ns The namespace URI of the root element of the document.
      * @param root The name of the root element of the document.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri)
         throws IOException {
@@ -252,7 +252,7 @@ public class SAXDocumentFactory
     /**
      * Creates a Document instance.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri)
         throws IOException {
@@ -265,7 +265,7 @@ public class SAXDocumentFactory
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param is The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri,
                                    InputStream is) throws IOException {
@@ -278,7 +278,7 @@ public class SAXDocumentFactory
      * Creates a Document instance.
      * @param uri The document URI.
      * @param is The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri, InputStream is)
         throws IOException {
@@ -293,7 +293,7 @@ public class SAXDocumentFactory
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri,
                                    Reader r) throws IOException {
@@ -308,7 +308,7 @@ public class SAXDocumentFactory
      * @param root The name of the root element of the document.
      * @param uri The document URI.
      * @param r an XMLReaderInstance
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String ns, String root, String uri,
                                    XMLReader r) throws IOException {
@@ -335,7 +335,7 @@ public class SAXDocumentFactory
      * Creates a Document instance.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     public Document createDocument(String uri, Reader r) throws IOException {
         InputSource inp = new InputSource(r);
@@ -349,7 +349,7 @@ public class SAXDocumentFactory
      * @param root The name of the root element.
      * @param uri The document URI.
      * @param is  The document input source.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     protected Document createDocument(String ns, String root, String uri,
                                       InputSource is)
@@ -415,7 +415,7 @@ public class SAXDocumentFactory
     /**
      * Creates a Document.
      * @param is  The document input source.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     protected Document createDocument(InputSource is)
         throws IOException {

--- a/batik-dom/src/main/resources/org/apache/batik/dom/resources/Messages.properties
+++ b/batik-dom/src/main/resources/org/apache/batik/dom/resources/Messages.properties
@@ -57,7 +57,7 @@ children.not.allowed = \
 The current node (type: {0}, name: {1}) cannot have children.
 
 cloning.error = \
-An error occured while cloning a node (type: {0}, name: {1}). \
+An error occurred while cloning a node (type: {0}, name: {1}). \
 The original error message was: "{2}".
 
 css.parser.class = \

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/AbstractGraphicsNode.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/AbstractGraphicsNode.java
@@ -866,7 +866,7 @@ public abstract class AbstractGraphicsNode implements GraphicsNode {
 
     /**
      * Returns the bounds of the area covered by this node, without
-     * taking any of its rendering attribute into accoun. That is,
+     * taking any of its rendering attribute into account. That is,
      * exclusive of any clipping, masking, filtering or stroking, for
      * example. The returned value is transformed by the concatenation
      * of the input transform and this node's transform.

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/CompositeGraphicsNode.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/CompositeGraphicsNode.java
@@ -345,7 +345,7 @@ public class CompositeGraphicsNode extends AbstractGraphicsNode
 
     /**
      * Returns the bounds of the area covered by this node, without taking any
-     * of its rendering attribute into accoun. That is, exclusive of any clipping,
+     * of its rendering attribute into account. That is, exclusive of any clipping,
      * masking, filtering or stroking, for example. The returned value is
      * transformed by the concatenation of the input transform and this node's
      * transform.

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/GraphicsNode.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/GraphicsNode.java
@@ -397,7 +397,7 @@ public interface GraphicsNode {
 
     /**
      * Returns the bounds of the area covered by this node, without
-     * taking any of its rendering attribute into accoun. That is,
+     * taking any of its rendering attribute into account. That is,
      * exclusive of any clipping, masking, filtering or stroking, for
      * example. The returned value is transformed by the concatenation
      * of the input transform and this node's transform.

--- a/batik-gvt/src/main/java/org/apache/batik/gvt/event/GraphicsNodeChangeEvent.java
+++ b/batik-gvt/src/main/java/org/apache/batik/gvt/event/GraphicsNodeChangeEvent.java
@@ -36,7 +36,7 @@ public class GraphicsNodeChangeEvent extends GraphicsNodeEvent {
     /**
      * The id for the "changeStarted" event. This change event occurs
      * when a change has started on a graphics node (but no changes have
-     * occured on the graphics node it's self).
+     * occurred on the graphics node it's self).
      */
     public static final int CHANGE_STARTED = CHANGE_FIRST;
 

--- a/batik-parser/src/main/java/org/apache/batik/parser/AngleHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/AngleHandler.java
@@ -29,37 +29,37 @@ package org.apache.batik.parser;
 public interface AngleHandler {
     /**
      * Invoked when the angle attribute parsing starts.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void startAngle() throws ParseException;
 
     /**
      * Invoked when a float value has been parsed.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void angleValue(float v) throws ParseException;
 
     /**
      * Invoked when 'deg' has been parsed.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void deg() throws ParseException;
 
     /**
      * Invoked when 'grad' has been parsed.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void grad() throws ParseException;
 
     /**
      * Invoked when 'rad' has been parsed.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void rad() throws ParseException;
 
     /**
      * Invoked when the angle attribute parsing ends.
-     * @exception ParseException if an error occured while processing the angle
+     * @exception ParseException if an error occurred while processing the angle
      */
     void endAngle() throws ParseException;
 }

--- a/batik-parser/src/main/java/org/apache/batik/parser/DefaultFragmentIdentifierHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/DefaultFragmentIdentifierHandler.java
@@ -49,7 +49,7 @@ public class DefaultFragmentIdentifierHandler
     /**
      * Invoked when an ID has been parsed.
      * @param s The string that represents the parsed ID.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void idReference(String s) throws ParseException {
@@ -61,7 +61,7 @@ public class DefaultFragmentIdentifierHandler
      * @param y the y coordinate of the viewbox.
      * @param width the width of the viewbox.
      * @param height the height of the viewbox.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void viewBox(float x, float y, float width, float height)
@@ -70,7 +70,7 @@ public class DefaultFragmentIdentifierHandler
 
     /**
      * Invoked when a view target specification starts.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void startViewTarget() throws ParseException {
@@ -79,7 +79,7 @@ public class DefaultFragmentIdentifierHandler
     /**
      * Invoked when a view target component has been parsed.
      * @param name the target name.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void viewTarget(String name) throws ParseException {
@@ -87,7 +87,7 @@ public class DefaultFragmentIdentifierHandler
 
     /**
      * Invoked when a view target specification ends.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void endViewTarget() throws ParseException {
@@ -164,7 +164,7 @@ public class DefaultFragmentIdentifierHandler
     /**
      * Invoked when a 'zoomAndPan' specification has been parsed.
      * @param magnify true if 'magnify' has been parsed.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     public void zoomAndPan(boolean magnify) {

--- a/batik-parser/src/main/java/org/apache/batik/parser/FragmentIdentifierHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/FragmentIdentifierHandler.java
@@ -32,7 +32,7 @@ public interface FragmentIdentifierHandler
 
     /**
      * Invoked when the fragment identifier starts.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void startFragmentIdentifier() throws ParseException;
@@ -40,7 +40,7 @@ public interface FragmentIdentifierHandler
     /**
      * Invoked when an ID has been parsed.
      * @param s The string that represents the parsed ID.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void idReference(String s) throws ParseException;
@@ -51,7 +51,7 @@ public interface FragmentIdentifierHandler
      * @param y y coordinate of the viewbox
      * @param width width of the viewbox
      * @param height height of the viewbox
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void viewBox(float x, float y, float width, float height)
@@ -59,7 +59,7 @@ public interface FragmentIdentifierHandler
 
     /**
      * Invoked when a view target specification starts.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void startViewTarget() throws ParseException;
@@ -68,14 +68,14 @@ public interface FragmentIdentifierHandler
      * Invoked when a identifier has been parsed within a view target
      * specification.
      * @param name the target name.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void viewTarget(String name) throws ParseException;
 
     /**
      * Invoked when a view target specification ends.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void endViewTarget() throws ParseException;
@@ -83,14 +83,14 @@ public interface FragmentIdentifierHandler
     /**
      * Invoked when a 'zoomAndPan' specification has been parsed.
      * @param magnify true if 'magnify' has been parsed.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void zoomAndPan(boolean magnify);
 
     /**
      * Invoked when the fragment identifier ends.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           fragment identifier
      */
     void endFragmentIdentifier() throws ParseException;

--- a/batik-parser/src/main/java/org/apache/batik/parser/PathHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/PathHandler.java
@@ -29,13 +29,13 @@ package org.apache.batik.parser;
 public interface PathHandler {
     /**
      * Invoked when the path starts.
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void startPath() throws ParseException;
 
     /**
      * Invoked when the path ends.
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void endPath() throws ParseException;
 
@@ -44,7 +44,7 @@ public interface PathHandler {
      * <p>Command : <b>m</b>
      * @param x the relative x coordinate for the end point
      * @param y the relative y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void movetoRel(float x, float y) throws ParseException;
 
@@ -53,14 +53,14 @@ public interface PathHandler {
      * <p>Command : <b>M</b>
      * @param x the absolute x coordinate for the end point
      * @param y the absolute y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void movetoAbs(float x, float y) throws ParseException;
 
     /**
      * Invoked when a closepath has been parsed.
      * <p>Command : <b>z</b> | <b>Z</b>
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void closePath() throws ParseException;
 
@@ -69,7 +69,7 @@ public interface PathHandler {
      * <p>Command : <b>l</b>
      * @param x the relative x coordinates for the end point
      * @param y the relative y coordinates for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoRel(float x, float y) throws ParseException;
 
@@ -78,7 +78,7 @@ public interface PathHandler {
      * <p>Command : <b>L</b>
      * @param x the absolute x coordinate for the end point
      * @param y the absolute y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoAbs(float x, float y) throws ParseException;
 
@@ -86,7 +86,7 @@ public interface PathHandler {
      * Invoked when an horizontal relative line command has been parsed.
      * <p>Command : <b>h</b>
      * @param x the relative X coordinate of the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoHorizontalRel(float x) throws ParseException;
 
@@ -94,7 +94,7 @@ public interface PathHandler {
      * Invoked when an horizontal absolute line command has been parsed.
      * <p>Command : <b>H</b>
      * @param x the absolute X coordinate of the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoHorizontalAbs(float x) throws ParseException;
 
@@ -102,7 +102,7 @@ public interface PathHandler {
      * Invoked when a vertical relative line command has been parsed.
      * <p>Command : <b>v</b>
      * @param y the relative Y coordinate of the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoVerticalRel(float y) throws ParseException;
 
@@ -110,7 +110,7 @@ public interface PathHandler {
      * Invoked when a vertical absolute line command has been parsed.
      * <p>Command : <b>V</b>
      * @param y the absolute Y coordinate of the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void linetoVerticalAbs(float y) throws ParseException;
 
@@ -123,7 +123,7 @@ public interface PathHandler {
      * @param y2 the relative y coordinate for the second control point
      * @param x the relative x coordinate for the end point
      * @param y the relative y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoCubicRel(float x1, float y1, 
                          float x2, float y2, 
@@ -139,7 +139,7 @@ public interface PathHandler {
      * @param y2 the absolute y coordinate for the second control point
      * @param x the absolute x coordinate for the end point
      * @param y the absolute y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoCubicAbs(float x1, float y1, 
                          float x2, float y2, 
@@ -155,7 +155,7 @@ public interface PathHandler {
      * @param y2 the relative y coordinate for the second control point
      * @param x the relative x coordinate for the end point
      * @param y the relative y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoCubicSmoothRel(float x2, float y2, 
                                float x, float y) throws ParseException;
@@ -170,7 +170,7 @@ public interface PathHandler {
      * @param y2 the absolute y coordinate for the second control point
      * @param x the absolute x coordinate for the end point
      * @param y the absolute y coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoCubicSmoothAbs(float x2, float y2, 
                                float x, float y) throws ParseException;
@@ -182,7 +182,7 @@ public interface PathHandler {
      * @param y1 the relative y coordinate for the control point
      * @param x the relative x coordinate for the end point
      * @param y the relative x coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoQuadraticRel(float x1, float y1, 
                              float x, float y) throws ParseException;
@@ -194,7 +194,7 @@ public interface PathHandler {
      * @param y1 the absolute y coordinate for the control point
      * @param x the absolute x coordinate for the end point
      * @param y the absolute x coordinate for the end point
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoQuadraticAbs(float x1, float y1, 
                              float x, float y) throws ParseException;
@@ -207,7 +207,7 @@ public interface PathHandler {
      * <p>Command : <b>t</b>
      * @param x the relative x coordinate for the end point 
      * @param y the relative y coordinate for the end point 
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoQuadraticSmoothRel(float x, float y) throws ParseException;
 
@@ -219,7 +219,7 @@ public interface PathHandler {
      * <p>Command : <b>T</b>
      * @param x the absolute x coordinate for the end point 
      * @param y the absolute y coordinate for the end point 
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void curvetoQuadraticSmoothAbs(float x, float y) throws ParseException;
 
@@ -234,7 +234,7 @@ public interface PathHandler {
      * @param sweepFlag the value of the sweep-flag 
      * @param x the relative x coordinate for the end point 
      * @param y the relative y coordinate for the end point 
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void arcRel(float rx, float ry, 
                 float xAxisRotation, 
@@ -253,7 +253,7 @@ public interface PathHandler {
      * @param sweepFlag the value of the sweep-flag 
      * @param x the absolute x coordinate for the end point 
      * @param y the absolute y coordinate for the end point 
-     * @exception ParseException if an error occured while processing the path
+     * @exception ParseException if an error occurred while processing the path
      */
     void arcAbs(float rx, float ry, 
                 float xAxisRotation, 

--- a/batik-parser/src/main/java/org/apache/batik/parser/PointsHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/PointsHandler.java
@@ -30,7 +30,7 @@ public interface PointsHandler {
 
     /**
      * Invoked when the points attribute starts.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           points
      */
     void startPoints() throws ParseException;
@@ -39,14 +39,14 @@ public interface PointsHandler {
      * Invoked when a point has been parsed.
      * @param x the x coordinate of the point
      * @param y the y coordinate of the point
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           points
      */
     void point(float x, float y) throws ParseException;
 
     /**
      * Invoked when the points attribute ends.
-     * @exception ParseException if an error occured while processing the
+     * @exception ParseException if an error occurred while processing the
      *                           points
      */
     void endPoints() throws ParseException;

--- a/batik-parser/src/main/java/org/apache/batik/parser/PreserveAspectRatioHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/PreserveAspectRatioHandler.java
@@ -29,98 +29,98 @@ package org.apache.batik.parser;
 public interface PreserveAspectRatioHandler {
     /**
      * Invoked when the PreserveAspectRatio parsing starts.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void startPreserveAspectRatio() throws ParseException;
 
     /**
      * Invoked when 'none' been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void none() throws ParseException;
 
     /**
      * Invoked when 'xMaxYMax' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMaxYMax() throws ParseException;
 
     /**
      * Invoked when 'xMaxYMid' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMaxYMid() throws ParseException;
 
     /**
      * Invoked when 'xMaxYMin' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMaxYMin() throws ParseException;
 
     /**
      * Invoked when 'xMidYMax' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMidYMax() throws ParseException;
 
     /**
      * Invoked when 'xMidYMid' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMidYMid() throws ParseException;
 
     /**
      * Invoked when 'xMidYMin' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMidYMin() throws ParseException;
 
     /**
      * Invoked when 'xMinYMax' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMinYMax() throws ParseException;
 
     /**
      * Invoked when 'xMinYMid' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMinYMid() throws ParseException;
 
     /**
      * Invoked when 'xMinYMin' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void xMinYMin() throws ParseException;
 
     /**
      * Invoked when 'meet' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void meet() throws ParseException;
 
     /**
      * Invoked when 'slice' has been parsed.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio 
      */
     void slice() throws ParseException;
 
     /**
      * Invoked when the PreserveAspectRatio parsing ends.
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the PreserveAspectRatio
      */
     void endPreserveAspectRatio() throws ParseException;

--- a/batik-parser/src/main/java/org/apache/batik/parser/TransformListHandler.java
+++ b/batik-parser/src/main/java/org/apache/batik/parser/TransformListHandler.java
@@ -30,7 +30,7 @@ public interface TransformListHandler {
     /**
      * Invoked when the tranform starts.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void startTransformList() throws ParseException;
@@ -38,7 +38,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'matrix(a, b, c, d, e, f)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void matrix(float a, float b, float c, float d, float e, float f)
@@ -47,7 +47,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'rotate(theta)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void rotate(float theta) throws ParseException;
@@ -55,7 +55,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'rotate(theta, cx, cy)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void rotate(float theta, float cx, float cy) throws ParseException;
@@ -63,7 +63,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'translate(tx)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void translate(float tx) throws ParseException;
@@ -71,7 +71,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'translate(tx, ty)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void translate(float tx, float ty) throws ParseException;
@@ -79,7 +79,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'scale(sx)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void scale(float sx) throws ParseException;
@@ -87,7 +87,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'scale(sx, sy)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void scale(float sx, float sy) throws ParseException;
@@ -95,7 +95,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'skewX(skx)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform 
      */
     void skewX(float skx) throws ParseException;
@@ -103,7 +103,7 @@ public interface TransformListHandler {
     /**
      * Invoked when 'skewY(sky)' has been parsed.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform
      */
     void skewY(float sky) throws ParseException;
@@ -111,7 +111,7 @@ public interface TransformListHandler {
     /**
      * Invoked when the transform ends.
      *
-     * @exception ParseException if an error occured while processing
+     * @exception ParseException if an error occurred while processing
      * the transform
      */
     void endTransformList() throws ParseException;

--- a/batik-parser/src/main/resources/org/apache/batik/parser/style/resources/Messages.properties
+++ b/batik-parser/src/main/resources/org/apache/batik/parser/style/resources/Messages.properties
@@ -25,11 +25,11 @@ The attribute with namespace URI "{0}" and local name "{1}" do\n \
 not have an associated CSSValueFactory.
 
 parser.exception = \
-An exception occured while parsing an attribute. The original message was:\n\
+An exception occurred while parsing an attribute. The original message was:\n\
 {0}.
 
 creation.exception = \
-An exception occured while creating a parser. The original message was:\n\
+An exception occurred while creating a parser. The original message was:\n\
 {0}.
 
 readonly.value = \

--- a/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGPreserveAspectRatio.java
+++ b/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/AbstractSVGPreserveAspectRatio.java
@@ -189,7 +189,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'none' been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void none() throws ParseException {
@@ -198,7 +198,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMaxYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMax() throws ParseException {
@@ -207,7 +207,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMaxYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMid() throws ParseException {
@@ -216,7 +216,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMaxYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMaxYMin() throws ParseException {
@@ -225,7 +225,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMidYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMax() throws ParseException {
@@ -234,7 +234,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMidYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMid() throws ParseException {
@@ -243,7 +243,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMidYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMidYMin() throws ParseException {
@@ -252,7 +252,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMinYMax' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMax() throws ParseException {
@@ -261,7 +261,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMinYMid' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMid() throws ParseException {
@@ -270,7 +270,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'xMinYMin' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void xMinYMin() throws ParseException {
@@ -279,7 +279,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'meet' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void meet() throws ParseException {
@@ -288,7 +288,7 @@ public abstract class AbstractSVGPreserveAspectRatio
 
         /**
          * Invoked when 'slice' has been parsed.
-         * @exception ParseException if an error occured while processing
+         * @exception ParseException if an error occurred while processing
          * the transform
          */
         public void slice() throws ParseException {

--- a/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/LiveAttributeException.java
+++ b/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/LiveAttributeException.java
@@ -34,7 +34,7 @@ public class LiveAttributeException extends RuntimeException {
     public static final short ERR_ATTRIBUTE_NEGATIVE  = 2;
 
     /**
-     * The element on which the error occured.
+     * The element on which the error occurred.
      */
     protected Element e;
 
@@ -58,7 +58,7 @@ public class LiveAttributeException extends RuntimeException {
      * Constructs a new <code>LiveAttributeException</code> with the specified
      * parameters.
      *
-     * @param e the element on which the error occured
+     * @param e the element on which the error occurred
      * @param an the attribute name
      * @param code the error code
      * @param val the malformed attribute value

--- a/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/SVGDocumentFactory.java
+++ b/batik-svg-dom/src/main/java/org/apache/batik/dom/svg/SVGDocumentFactory.java
@@ -36,7 +36,7 @@ public interface SVGDocumentFactory extends DocumentFactory {
     /**
      * Creates a SVG Document instance.
      * @param uri The document URI.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     SVGDocument createSVGDocument(String uri) throws IOException;
 
@@ -44,7 +44,7 @@ public interface SVGDocumentFactory extends DocumentFactory {
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param is The document input stream.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     SVGDocument createSVGDocument(String uri, InputStream is) 
         throws IOException;
@@ -53,7 +53,7 @@ public interface SVGDocumentFactory extends DocumentFactory {
      * Creates a SVG Document instance.
      * @param uri The document URI.
      * @param r The document reader.
-     * @exception IOException if an error occured while reading the document.
+     * @exception IOException if an error occurred while reading the document.
      */
     SVGDocument createSVGDocument(String uri, Reader r) throws IOException;
 

--- a/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/DOMViewer.java
+++ b/batik-svgbrowser/src/main/java/org/apache/batik/apps/svgbrowser/DOMViewer.java
@@ -1192,7 +1192,7 @@ public class DOMViewer extends JFrame implements ActionMap {
 
         /**
          * Checks whether the DOMViewer can be used to edit the document and if
-         * true refreshes the DOMViewer after the DOM Mutation event occured.
+         * true refreshes the DOMViewer after the DOM Mutation event occurred.
          *
          * @param runnable
          *            The runnable to invoke for refresh
@@ -1298,7 +1298,7 @@ public class DOMViewer extends JFrame implements ActionMap {
         }
 
         /**
-         * Checks what type of the "DOMAttrModified" mutation event occured, and
+         * Checks what type of the "DOMAttrModified" mutation event occurred, and
          * invokes the appropriate method to register the change.
          *
          * @param mevt
@@ -1338,8 +1338,8 @@ public class DOMViewer extends JFrame implements ActionMap {
         }
 
         /**
-         * Checks if the document change that occured should be registered. If
-         * the document change has occured out of the DOMViewer, the state of
+         * Checks if the document change that occurred should be registered. If
+         * the document change has occurred out of the DOMViewer, the state of
          * the history browser should be HistoryBrowserState.IDLE. Otherwise, if
          * the DOMViewer caused the change, one of the following states is
          * active: HistoryBrowserState.EXECUTING, HistoryBrowserState.UNDOING,
@@ -1360,7 +1360,7 @@ public class DOMViewer extends JFrame implements ActionMap {
 
         /**
          * Puts the document change in the current history browser's interface
-         * compound command if the document change occured outside of the
+         * compound command if the document change occurred outside of the
          * DOMViewer.
          *
          * @param mevt

--- a/batik-svgbrowser/src/main/resources/org/apache/batik/apps/svgbrowser/resources/GUI.properties
+++ b/batik-svgbrowser/src/main/resources/org/apache/batik/apps/svgbrowser/resources/GUI.properties
@@ -670,6 +670,6 @@ no produce any content.
 XMLInputHandler.error.transform.output.wrong.ns = The result of the XSL transformation \
 produced a document which is not in the SVG namespace (http://www.w3.org/2000/svg)
 
-XMLInputHandler.error.result.generated.exception = An error occured when processing the \
+XMLInputHandler.error.result.generated.exception = An error occurred when processing the \
 result of the transformation applied to your document. Check that the transformation does \
 not produce an empty document and that it is a well formed SVG document.

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/AbstractSVGConverter.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/AbstractSVGConverter.java
@@ -25,9 +25,9 @@ import java.util.Map;
 
 /**
  * Abstract class with common utility methods used by subclasses
- * for specific convertion operations. It holds a reference to a
+ * for specific conversion operations. It holds a reference to a
  * domFactory Document, which many implementations use, and provides
- * a convenience method, to offers a convertion of double values
+ * a convenience method, to offers a conversion of double values
  * to String that remove the trailing '.' character on integral
  * values.
  *

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/AbstractSVGFilterConverter.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/AbstractSVGFilterConverter.java
@@ -25,9 +25,9 @@ import java.util.Map;
 
 /**
  * Abstract class with common utility methods used by subclasses
- * for specific convertion operations. It holds a reference to a
+ * for specific conversion operations. It holds a reference to a
  * domFactory Document, which many implementations use, and provides
- * a convenience method, to offers a convertion of double values
+ * a convenience method, to offers a conversion of double values
  * to String that remove the trailing '.' character on integral
  * values.
  *

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/DOMTreeManager.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/DOMTreeManager.java
@@ -258,7 +258,7 @@ public class DOMTreeManager implements SVGSyntax, ErrorConstants {
                 createElementNS(SVG_NAMESPACE_URI, SVG_SVG_TAG);
         }
 
-        // Enable background if required by AlphaComposite convertion
+        // Enable background if required by AlphaComposite conversion
         if (gcConverter.getCompositeConverter().
             getAlphaCompositeConverter().requiresBackgroundAccess())
             svg.setAttributeNS

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGBufferedImageOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGBufferedImageOp.java
@@ -39,22 +39,22 @@ import java.util.List;
  */
 public class SVGBufferedImageOp extends AbstractSVGFilterConverter {
     /**
-     * All LookupOp convertion is handed to svgLookupOp
+     * All LookupOp conversion is handed to svgLookupOp
      */
     private SVGLookupOp svgLookupOp;
 
     /**
-     * All RescaleOp convertion is handed to svgRescaleOp
+     * All RescaleOp conversion is handed to svgRescaleOp
      */
     private SVGRescaleOp svgRescaleOp;
 
     /**
-     * All ConvolveOp convertion is handed to svgConvolveOp
+     * All ConvolveOp conversion is handed to svgConvolveOp
      */
     private SVGConvolveOp svgConvolveOp;
 
     /**
-     * All custom BufferedImageOp convertion is handed to '
+     * All custom BufferedImageOp conversion is handed to '
      * svgCustomBufferedImageOp.
      */
     private SVGCustomBufferedImageOp svgCustomBufferedImageOp;

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGComposite.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGComposite.java
@@ -44,12 +44,12 @@ import org.apache.batik.ext.awt.g2d.GraphicContext;
  */
 public class SVGComposite implements SVGConverter {
     /**
-     * All AlphaComposite convertion is handed to svgAlphaComposite
+     * All AlphaComposite conversion is handed to svgAlphaComposite
      */
     private SVGAlphaComposite svgAlphaComposite;
 
     /**
-     * All custom Composite convertion is handed to svgCustomComposite
+     * All custom Composite conversion is handed to svgCustomComposite
      */
     private SVGCustomComposite svgCustomComposite;
 

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomBufferedImageOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomBufferedImageOp.java
@@ -58,7 +58,7 @@ public class SVGCustomBufferedImageOp extends AbstractSVGFilterConverter {
 
         if (filterDesc == null) {
             // First time this filter is used. Request handler
-            // to do the convertion
+            // to do the conversion
             filterDesc =
                 generatorContext.extensionHandler.
                 handleFilter(filter, filterRect, generatorContext);

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomComposite.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomComposite.java
@@ -66,7 +66,7 @@ public class SVGCustomComposite extends AbstractSVGConverter {
 
         if (compositeDesc == null) {
             // First time this composite is used. Request handler
-            // to do the convertion
+            // to do the conversion
             SVGCompositeDescriptor desc =
                 generatorContext.
                 extensionHandler.handleComposite(composite,

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomPaint.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGCustomPaint.java
@@ -64,7 +64,7 @@ public class SVGCustomPaint extends AbstractSVGConverter {
 
         if (paintDesc == null) {
             // First time this paint is used. Request handler
-            // to do the convertion
+            // to do the conversion
             paintDesc =
                 generatorContext.extensionHandler.
                 handlePaint(paint,

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGGraphics2D.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGGraphics2D.java
@@ -270,7 +270,7 @@ public class SVGGraphics2D extends AbstractGraphics2D
      * @param extensionHandler defines how Java 2D API extensions map
      *                         to SVG Nodes.
      * @param textAsShapes if true, all text is turned into SVG shapes in the
-     *        convertion. No SVG text is output.
+     *        conversion. No SVG text is output.
      *
      * @exception SVGGraphics2DRuntimeException if domFactory is null.
      */
@@ -309,7 +309,7 @@ public class SVGGraphics2D extends AbstractGraphics2D
      * @param generatorCtx the <code>SVGGeneratorContext</code> instance
      * that will provide all useful information to the generator.
      * @param textAsShapes if true, all text is turned into SVG shapes in the
-     *        convertion. No SVG text is output.
+     *        conversion. No SVG text is output.
      *
      * @exception SVGGraphics2DRuntimeException if generatorContext is null.
      */

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLookupOp.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGLookupOp.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
 public class SVGLookupOp extends AbstractSVGFilterConverter {
 
     /**
-     * Gamma for linear to sRGB convertion
+     * Gamma for linear to sRGB conversion
      */
     private static final double GAMMA = 1.0/2.4;
 

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPaint.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGPaint.java
@@ -39,17 +39,17 @@ import org.apache.batik.ext.awt.g2d.GraphicContext;
  */
 public class SVGPaint implements SVGConverter {
     /**
-     * All GradientPaint convertions are handed to svgLinearGradient
+     * All GradientPaint conversions are handed to svgLinearGradient
      */
     private SVGLinearGradient svgLinearGradient;
 
     /**
-     * All TexturePaint convertions are handed to svgTextureGradient
+     * All TexturePaint conversions are handed to svgTextureGradient
      */
     private SVGTexturePaint svgTexturePaint;
 
     /**
-     * All Color convertions are handed to svgColor
+     * All Color conversions are handed to svgColor
      */
     private SVGColor svgColor;
 

--- a/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/Main.java
+++ b/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/Main.java
@@ -213,7 +213,7 @@ public class Main implements SVGConverterController {
                         w = Float.parseFloat(wStr);
                         h = Float.parseFloat(hStr);
                     }catch(NumberFormatException e){
-                        // If an error occured, the x, y, w, h
+                        // If an error occurred, the x, y, w, h
                         // values will not be valid
                     }
 
@@ -270,7 +270,7 @@ public class Main implements SVGConverterController {
                         g = Integer.parseInt(gStr);
                         b = Integer.parseInt(bStr);
                     }catch(NumberFormatException e){
-                        // If an error occured, the a, r, g, b
+                        // If an error occurred, the a, r, g, b
                         // values will not be in the 0-255 range
                         // and the next if test will fail
                     }

--- a/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/SVGConverter.java
+++ b/batik-svgrasterizer/src/main/java/org/apache/batik/apps/rasterizer/SVGConverter.java
@@ -173,7 +173,7 @@ public class SVGConverter {
         = "SVGConverter.error.unable.to.create.output.dir";
 
     //
-    // Reported when an error occurs while convertion the
+    // Reported when an error occurs while conversion the
     // source file.
     //
     public static final String ERROR_WHILE_RASTERIZING_FILE

--- a/batik-swing/src/main/java/org/apache/batik/swing/svg/GVTTreeBuilder.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/svg/GVTTreeBuilder.java
@@ -125,7 +125,7 @@ public class GVTTreeBuilder extends HaltingThread {
     }
 
     /**
-     * Returns the exception, if any occured.
+     * Returns the exception, if any occurred.
      */
     public Exception getException() {
         return exception;

--- a/batik-swing/src/main/java/org/apache/batik/swing/svg/JSVGComponent.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/svg/JSVGComponent.java
@@ -194,7 +194,7 @@ import org.w3c.dom.svg.SVGSVGElement;
  * resolution used to display an SVG document (controling the pixel to
  * millimeter conversion factor), perform an operation in respond to a click on
  * an hyperlink, control the default language to use, or specify a user
- * stylesheet, or how to display errors when an error occured while
+ * stylesheet, or how to display errors when an error occurred while
  * building/rendering a document (invalid XML file, missing attributes...).</p>
  *
  * @author <a href="mailto:stephane@hillion.org">Stephane Hillion</a>

--- a/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGDocumentLoader.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGDocumentLoader.java
@@ -107,7 +107,7 @@ public class SVGDocumentLoader extends HaltingThread {
     }
 
     /**
-     * Returns the exception, if any occured.
+     * Returns the exception, if any occurred.
      */
     public Exception getException() {
         return exception;

--- a/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGDocumentLoaderEvent.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGDocumentLoaderEvent.java
@@ -49,7 +49,7 @@ public class SVGDocumentLoaderEvent extends EventObject {
 
     /**
      * Returns the associated SVG document, or null if the loading
-     * was just started or an error occured.
+     * was just started or an error occurred.
      */
     public SVGDocument getSVGDocument() {
         return svgDocument;

--- a/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGLoadEventDispatcher.java
+++ b/batik-swing/src/main/java/org/apache/batik/swing/svg/SVGLoadEventDispatcher.java
@@ -131,7 +131,7 @@ public class SVGLoadEventDispatcher extends HaltingThread {
     }
 
     /**
-     * Returns the exception, if any occured.
+     * Returns the exception, if any occurred.
      */
     public Exception getException() {
         return exception;

--- a/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
@@ -728,7 +728,7 @@ abstract class AbstractConfigTest extends AbstractTest implements SVGConverterCo
         computedConfig.sources = new ArrayList( sources );
         computedConfig.dest = new ArrayList( dest );
         computedConfig.hints = new HashMap(hints);
-        return false; // Do not proceed with the convertion process,
+        return false; // Do not proceed with the conversion process,
         // we are only checking the config in this test.
     }
 
@@ -749,7 +749,7 @@ abstract class AbstractConfigTest extends AbstractTest implements SVGConverterCo
 }
 
 /**
- * Tests that a convertion task goes without exception.
+ * Tests that a conversion task goes without exception.
  */
 class OperationTest extends AbstractTest{
     public TestReport runImpl() throws Exception {
@@ -777,7 +777,7 @@ class TranscoderConfigTest extends AbstractConfigTest {
     /**
      * @param dstType type of result image
      * @param expectedTranscoderClass class for the Transcoder expected to perform
-     *        the convertion.
+     *        the conversion.
      */
     public TranscoderConfigTest(DestinationType dstType,
                                 Class expectedTranscoderClass){

--- a/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/apps/rasterizer/SVGConverterTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.batik.apps.rasterizer;
 
+import org.apache.batik.svggen.SVGConverter;
 import org.apache.batik.test.*;
 import org.apache.batik.test.svg.ImageCompareTest;
 import org.apache.batik.transcoder.Transcoder;
@@ -47,7 +48,7 @@ public class SVGConverterTest extends DefaultTestSuite {
         AbstractTest t = null;
 
         //
-        // Test Trancoder usage
+        // Test Transcoder usage
         //
         t = new TranscoderConfigTest(DestinationType.PNG,
                                      org.apache.batik.transcoder.image.PNGTranscoder.class);
@@ -441,7 +442,7 @@ abstract class AbstractConfigTest extends AbstractTest implements SVGConverterCo
         = "ConfigTest.entry.key.expected.transcoder.class";
 
     public static final String ENTRY_KEY_COMPUTED_TRANSCODER_CLASS
-        = "ConfigTest.entry.key.computed.trancoder.class";
+        = "ConfigTest.entry.key.computed.transcoder.class";
 
     /**
      * Error if the hints do not match

--- a/batik-test-old/src/test/java/org/apache/batik/css/engine/value/PropertyManagerTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/css/engine/value/PropertyManagerTest.java
@@ -67,7 +67,7 @@ public class PropertyManagerTest extends AbstractTest {
         "PropertyManagerTest.error.invalid.value";
 
     /**
-     * The error code if an exception occured while creating the manager.
+     * The error code if an exception occurred while creating the manager.
      */
     public static final String ERROR_INSTANTIATION =
         "PropertyManagerTest.error.instantiation";

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/ATransform.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/ATransform.java
@@ -25,7 +25,7 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 
 /**
- * This test validates the convertion of Java 2D AffineTransform into SVG
+ * This test validates the conversion of Java 2D AffineTransform into SVG
  * Shapes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/AttributedCharacterIterator.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/AttributedCharacterIterator.java
@@ -26,7 +26,7 @@ import java.text.AttributedString;
 
 
 /**
- * This test validates the convertion of Java 2D AffineTransform into SVG
+ * This test validates the conversion of Java 2D AffineTransform into SVG
  * Shapes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/BEExample.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/BEExample.java
@@ -25,7 +25,7 @@ import java.awt.RenderingHints;
 
 
 /**
- * This test validates the convertion of Java 2D AffineTransform into SVG
+ * This test validates the conversion of Java 2D AffineTransform into SVG
  * Shapes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/BStroke.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/BStroke.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.geom.*;
 
 /**
- * This test validates convertion of BasicStroke
+ * This test validates conversion of BasicStroke
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>
  * @author <a href="mailto:vhardy@eng.sun.com">Vincent Hardy</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/BasicShapes.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/BasicShapes.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.geom.*;
 
 /**
- * This test validates the convertion of Java 2D shapes into SVG
+ * This test validates the conversion of Java 2D shapes into SVG
  * Shapes.
  *
  * @author <a href="mailto:vhardy@eng.sun.com">Vincent Hardy</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/BasicShapes2.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/BasicShapes2.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.geom.*;
 
 /**
- * This test validates the convertion of Java 2D shapes into SVG
+ * This test validates the conversion of Java 2D shapes into SVG
  * Shapes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Clip.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Clip.java
@@ -23,7 +23,7 @@ import java.awt.geom.*;
 import java.awt.image.*;
 
 /**
- * This test validates convertion of Java 2D clip inot SVG clipPath
+ * This test validates conversion of Java 2D clip inot SVG clipPath
  * definition and attributes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Color1.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Color1.java
@@ -23,7 +23,7 @@ import java.awt.RenderingHints;
 import java.awt.Font;
 
 /**
- * This test validates convertion of Java 2D Color into SVG fill,
+ * This test validates conversion of Java 2D Color into SVG fill,
  * stroke and opacity attributes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Font1.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Font1.java
@@ -25,7 +25,7 @@ import java.awt.RenderingHints;
 import java.awt.font.FontRenderContext;
 
 /**
- * This test validates the convertion of Java 2D Fonts into
+ * This test validates the conversion of Java 2D Fonts into
  * SVG font attributes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Font2.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Font2.java
@@ -25,11 +25,11 @@ import java.awt.RenderingHints;
 import java.awt.font.FontRenderContext;
 
 /**
- * This test validates the convertion of Java 2D text into
+ * This test validates the conversion of Java 2D text into
  * SVG Shapes, one of the options of the SVGGraphics2D constructor.
  * This is the same test as Font testing with regards to the
  * Java 2D API code, except that it validates text to shapes
- * convertion.
+ * conversion.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>
  * @author <a href="mailto:vhardy@eng.sun.com">Vincent Hardy</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/GVector.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/GVector.java
@@ -24,7 +24,7 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 
 /**
- * This test validates the convertion of Java 2D GlyphVectors
+ * This test validates the conversion of Java 2D GlyphVectors
  * SVG Shapes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Gradient.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Gradient.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.geom.*;
 
 /**
- * This test validates the convertion of Java 2D GradientPaints
+ * This test validates the conversion of Java 2D GradientPaints
  * into SVG linearGradient definition and reference.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/GraphicObjects.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/GraphicObjects.java
@@ -23,7 +23,7 @@ import java.awt.geom.*;
 import java.awt.image.*;
 
 /**
- * This test validates the convertion of the three elementary
+ * This test validates the conversion of the three elementary
  * thypes of Java 2D API graphic objects: shapes, text and
  * images
  *

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/IdentityTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/IdentityTest.java
@@ -23,7 +23,7 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 
 /**
- * This test validates the convertion of Java 2D AffineTransform into SVG
+ * This test validates the conversion of Java 2D AffineTransform into SVG
  * Shapes.
  *
  * @author <a href="mailto:vincent.hardy@sun.com">Vincent Hardy</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Lookup.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Lookup.java
@@ -30,7 +30,7 @@ import java.awt.image.ByteLookupTable;
 import java.awt.image.LookupTable;
 
 /**
- * This test validates the convertion of Java 2D LookupOp
+ * This test validates the conversion of Java 2D LookupOp
  * into an SVG filer.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/NegativeLengths.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/NegativeLengths.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.geom.*;
 
 /**
- * This test validates the convertion of Java 2D negative length values:<br>
+ * This test validates the conversion of Java 2D negative length values:<br>
  * - On rectangles: a negative width or height makes the rectangle invisible.<br>
  * - On rounded rectangles: a negative width or height makes the rectangle invisible.<br>
  * - On ellipses: a negative width or height makes the ellipse invisible<br>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Paints.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Paints.java
@@ -28,7 +28,7 @@ import java.awt.TexturePaint;
 import java.awt.image.BufferedImage;
 
 /**
- * This test validates the convertion of Java 2D paints
+ * This test validates the conversion of Java 2D paints
  * into an SVG attributes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/RHints.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/RHints.java
@@ -23,7 +23,7 @@ import java.awt.geom.*;
 import java.awt.image.*;
 
 /**
- * This test validates the convertion of Java 2D RenderingHints
+ * This test validates the conversion of Java 2D RenderingHints
  * into an SVG attributes.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Rescale.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Rescale.java
@@ -28,7 +28,7 @@ import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 
 /**
- * This test validates the convertion of Java 2D RescaleOp
+ * This test validates the conversion of Java 2D RescaleOp
  * into an SVG filer.
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/svggen/Texture.java
+++ b/batik-test-old/src/test/java/org/apache/batik/svggen/Texture.java
@@ -25,7 +25,7 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 
 /**
- * This test validates the convertion of Java 2D TexturePaints
+ * This test validates the conversion of Java 2D TexturePaints
  * into SVG patterns and fill and fill-opacity values
  *
  * @author <a href="mailto:cjolif@ilog.fr">Christophe Jolif</a>

--- a/batik-test-old/src/test/java/org/apache/batik/test/xml/JUnitRunnerTestCase.java
+++ b/batik-test-old/src/test/java/org/apache/batik/test/xml/JUnitRunnerTestCase.java
@@ -123,7 +123,7 @@ public class JUnitRunnerTestCase {
     public JUnitRunnerTestCase(Test test) {
         this.test = test;
     }
-    
+
     @org.junit.Test
     public void test() throws ParserConfigurationException, SAXException, TestException, IOException {
         String id = getId(test);
@@ -224,7 +224,7 @@ public class JUnitRunnerTestCase {
 "transcoder.image.hints.media.screen",
 "transcoder.image.hints.defaultFontFamily.Arial",
 "transcoder.image.hints.defaultFontFamily.Times",
-"trancoder.image.hints.defaultFontFamily.TotoTimes",
+"transcoder.image.hints.defaultFontFamily.TotoTimes",
 "transcoder.image.hints.alternateStylesheet.s1",
 "transcoder.image.hints.alternateStylesheet.s2",
 "transcoder.image.hints.alternateStylesheet.s3",

--- a/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractImageTranscoderTest extends AbstractTest {
         "AbstractImageTranscoderTest.error.difference.image";
 
     /**
-     * Error when an exception occured while transcoding.
+     * Error when an exception occurred while transcoding.
      */
     public static final String ERROR_TRANSCODING =
         "AbstractImageTranscoderTest.error.transcoder.exception";
@@ -252,7 +252,7 @@ public abstract class AbstractImageTranscoderTest extends AbstractTest {
          *
          * @param img the image to write
          * @param output the output (ignored)
-         * @throw TranscoderException if an error occured while storing the
+         * @throw TranscoderException if an error occurred while storing the
          * image
          */
         public void writeImage(BufferedImage img, TranscoderOutput output)

--- a/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
@@ -222,7 +222,7 @@ public abstract class AbstractImageTranscoderTest extends AbstractTest {
      */
     protected class DiffImageTranscoder extends ImageTranscoder {
 
-        /** The result of the image comparaison. */
+        /** The result of the image comparison. */
         protected boolean state;
 
         /** The reference image. */

--- a/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
+++ b/batik-test-old/src/test/java/org/apache/batik/transcoder/image/AbstractImageTranscoderTest.java
@@ -252,7 +252,7 @@ public abstract class AbstractImageTranscoderTest extends AbstractTest {
          *
          * @param img the image to write
          * @param output the output (ignored)
-         * @throw TranscoderException if an error occurred while storing the
+         * @throws TranscoderException if an error occurred while storing the
          * image
          */
         public void writeImage(BufferedImage img, TranscoderOutput output)

--- a/batik-test-svg/src/main/java/org/apache/batik/test/svg/AbstractRenderingAccuracyTest.java
+++ b/batik-test-svg/src/main/java/org/apache/batik/test/svg/AbstractRenderingAccuracyTest.java
@@ -135,7 +135,7 @@ public abstract class AbstractRenderingAccuracyTest extends AbstractTest {
         = "SVGRenderingAccuracyTest.entry.key.difference.image";
 
     /**
-     * Entry describing that an internal error occured while
+     * Entry describing that an internal error occurred while
      * generating the test failure description
      */
     public static final String ENTRY_KEY_INTERNAL_ERROR

--- a/batik-test-svg/src/main/java/org/apache/batik/test/svg/SVGOnLoadExceptionTest.java
+++ b/batik-test-svg/src/main/java/org/apache/batik/test/svg/SVGOnLoadExceptionTest.java
@@ -98,14 +98,14 @@ public class SVGOnLoadExceptionTest extends AbstractTest {
         = "SVGOnLoadExceptionTest.error.exception.did.not.occur";
 
     /**
-     * Error when an exception occured, but not of the expected
+     * Error when an exception occurred, but not of the expected
      * class
      */
     public static final String ERROR_UNEXPECTED_EXCEPTION
         = "SVGOnLoadExceptionTest.error.unexpected.exception";
 
     /**
-     * Error when a BridgeException occured, as expected, but
+     * Error when a BridgeException occurred, as expected, but
      * with an unexpected error code
      */
     public static final String ERROR_UNEXPECTED_ERROR_CODE

--- a/batik-test-svg/src/main/java/org/apache/batik/test/svg/SVGRenderingAccuracyTest.java
+++ b/batik-test-svg/src/main/java/org/apache/batik/test/svg/SVGRenderingAccuracyTest.java
@@ -206,7 +206,7 @@ public class SVGRenderingAccuracyTest extends AbstractRenderingAccuracyTest {
          * @param document the document to transcode
          * @param uri the uri of the document or null if any
          * @param output the ouput where to transcode
-         * @exception TranscoderException if an error occured while transcoding
+         * @exception TranscoderException if an error occurred while transcoding
          */
         protected void transcode(Document document,
                                  String uri,

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/DefaultErrorHandler.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/DefaultErrorHandler.java
@@ -20,8 +20,8 @@ package org.apache.batik.transcoder;
 
 /**
  * A default <code>ErrorHandler</code> that throws a
- * <code>TranscoderException</code> when a fatal error occured and display
- * a message when a warning or an error occured.
+ * <code>TranscoderException</code> when a fatal error occurred and display
+ * a message when a warning or an error occurred.
  *
  * @author <a href="mailto:Thierry.Kormann@sophia.inria.fr">Thierry Kormann</a>
  * @version $Id$
@@ -29,7 +29,7 @@ package org.apache.batik.transcoder;
 public class DefaultErrorHandler implements ErrorHandler {
 
     /**
-     * Invoked when an error occured while transcoding.
+     * Invoked when an error occurred while transcoding.
      * @param ex the error informations encapsulated in a TranscoderException
      * @exception TranscoderException if the method want to forward
      * the exception
@@ -39,7 +39,7 @@ public class DefaultErrorHandler implements ErrorHandler {
     }
 
     /**
-     * Invoked when an fatal error occured while transcoding.
+     * Invoked when an fatal error occurred while transcoding.
      * @param ex the fatal error informations encapsulated in a
      * TranscoderException
      * @exception TranscoderException if the method want to forward
@@ -50,7 +50,7 @@ public class DefaultErrorHandler implements ErrorHandler {
     }
 
     /**
-     * Invoked when a warning occured while transcoding.
+     * Invoked when a warning occurred while transcoding.
      * @param ex the warning informations encapsulated in a TranscoderException
      * @exception TranscoderException if the method want to forward
      * the exception

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/ErrorHandler.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/ErrorHandler.java
@@ -42,7 +42,7 @@ package org.apache.batik.transcoder;
 public interface ErrorHandler {
 
     /**
-     * Invoked when an error occured while transcoding.
+     * Invoked when an error occurred while transcoding.
      * @param ex the error informations encapsulated in a TranscoderException
      * @exception TranscoderException if the method want to forward
      * the exception
@@ -50,7 +50,7 @@ public interface ErrorHandler {
     void error(TranscoderException ex) throws TranscoderException;
 
     /**
-     * Invoked when an fatal error occured while transcoding.
+     * Invoked when an fatal error occurred while transcoding.
      * @param ex the fatal error informations encapsulated in a
      * TranscoderException
      * @exception TranscoderException if the method want to forward
@@ -59,7 +59,7 @@ public interface ErrorHandler {
     void fatalError(TranscoderException ex) throws TranscoderException;
 
     /**
-     * Invoked when a warning occured while transcoding.
+     * Invoked when a warning occurred while transcoding.
      * @param ex the warning informations encapsulated in a TranscoderException
      * @exception TranscoderException if the method want to forward
      * the exception

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/SVGAbstractTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/SVGAbstractTranscoder.java
@@ -166,7 +166,7 @@ public abstract class SVGAbstractTranscoder extends XMLAbstractTranscoder {
      * @param document the document to transcode
      * @param uri the uri of the document or null if any
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     protected void transcode(Document document,
                              String uri,

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/Transcoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/Transcoder.java
@@ -32,7 +32,7 @@ public interface Transcoder {
      * Transcodes the specified input in the specified output.
      * @param input the input to transcode
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     void transcode(TranscoderInput input, TranscoderOutput output)
             throws TranscoderException;

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/XMLAbstractTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/XMLAbstractTranscoder.java
@@ -67,7 +67,7 @@ public abstract class XMLAbstractTranscoder extends AbstractTranscoder {
      *
      * @param input the XML input to transcode
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     public void transcode(TranscoderInput input, TranscoderOutput output)
             throws TranscoderException {
@@ -168,7 +168,7 @@ public abstract class XMLAbstractTranscoder extends AbstractTranscoder {
      * @param document the document to transcode
      * @param uri the uri of the document or null if any
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     protected abstract void transcode(Document document,
                                       String uri,

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/ImageTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/ImageTranscoder.java
@@ -81,7 +81,7 @@ public abstract class ImageTranscoder extends SVGAbstractTranscoder {
      * @param document the document to transcode
      * @param uri the uri of the document or null if any
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     protected void transcode(Document document,
                              String uri,
@@ -195,7 +195,7 @@ public abstract class ImageTranscoder extends SVGAbstractTranscoder {
      * Writes the specified image to the specified output.
      * @param img the image to write
      * @param output the output where to store the image
-     * @throws TranscoderException if an error occured while storing the image
+     * @throws TranscoderException if an error occurred while storing the image
      */
     public abstract void writeImage(BufferedImage img, TranscoderOutput output)
         throws TranscoderException;

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/JPEGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/JPEGTranscoder.java
@@ -59,7 +59,7 @@ public class JPEGTranscoder extends ImageTranscoder {
      * Writes the specified image to the specified output.
      * @param img the image to write
      * @param output the output where to store the image
-     * @throws TranscoderException if an error occured while storing the image
+     * @throws TranscoderException if an error occurred while storing the image
      */
     public void writeImage(BufferedImage img, TranscoderOutput output)
             throws TranscoderException {

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
@@ -50,7 +50,7 @@ public class PNGTranscoder extends ImageTranscoder {
     public UserAgent getUserAgent() {
         return this.userAgent;
     }
-    
+
     /**
      * Creates a new ARGB image with the specified dimension.
      * @param width the image width in pixels
@@ -78,7 +78,7 @@ public class PNGTranscoder extends ImageTranscoder {
             return null;
         }
     }
-    
+
     /**
      * Writes the specified image to the specified output.
      * @param img the image to write
@@ -120,23 +120,23 @@ public class PNGTranscoder extends ImageTranscoder {
         }
         if (adapter == null) {
             throw new TranscoderException(
-                    "Could not write PNG file because no WriteAdapter is availble");
+                    "Could not write PNG file because no WriteAdapter is available");
         }
         adapter.writeImage(this, img, output);
     }
-    
+
     // --------------------------------------------------------------------
     // PNG specific interfaces
     // --------------------------------------------------------------------
 
     /**
-     * This interface is used by <code>PNGTranscoder</code> to write PNG images 
+     * This interface is used by <code>PNGTranscoder</code> to write PNG images
      * through different codecs.
      *
      * @version $Id$
      */
     public interface WriteAdapter {
-        
+
         /**
          * Writes the specified image to the specified output.
          * @param transcoder the calling PNGTranscoder
@@ -144,11 +144,11 @@ public class PNGTranscoder extends ImageTranscoder {
          * @param output the output where to store the image
          * @throws TranscoderException if an error occured while storing the image
          */
-        void writeImage(PNGTranscoder transcoder, BufferedImage img, 
+        void writeImage(PNGTranscoder transcoder, BufferedImage img,
                 TranscoderOutput output) throws TranscoderException;
 
     }
-    
+
 
     // --------------------------------------------------------------------
     // Keys definition
@@ -176,9 +176,9 @@ public class PNGTranscoder extends ImageTranscoder {
      *   </tr>
      *   <tr>
      *     <th valign="top" align="right">Description:</th>
-     *     <td valign="top">Controls the gamma correction of the PNG image. 
-     *       A value of zero for gamma disables the generation 
-     *       of a gamma chunk.  No value causes an sRGB chunk 
+     *     <td valign="top">Controls the gamma correction of the PNG image.
+     *       A value of zero for gamma disables the generation
+     *       of a gamma chunk.  No value causes an sRGB chunk
      *       to be generated.</td>
      *   </tr>
      * </table>
@@ -217,11 +217,11 @@ public class PNGTranscoder extends ImageTranscoder {
      *   </tr>
      *   <tr>
      *     <th valign="top" align="right">Description:</th>
-     *     <td valign="top">Turns on the reduction of the image to index 
-     *       colors by specifying color bit depth, 1, 2, 4 or 8. The resultant 
+     *     <td valign="top">Turns on the reduction of the image to index
+     *       colors by specifying color bit depth, 1, 2, 4 or 8. The resultant
      *       PNG will be an indexed PNG with color bit depth specified.</td>
      *   </tr>
-     * </table> 
+     * </table>
      */
     public static final TranscodingHints.Key KEY_INDEXED
         = new IntegerKey();

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/PNGTranscoder.java
@@ -83,7 +83,7 @@ public class PNGTranscoder extends ImageTranscoder {
      * Writes the specified image to the specified output.
      * @param img the image to write
      * @param output the output where to store the image
-     * @throws TranscoderException if an error occured while storing the image
+     * @throws TranscoderException if an error occurred while storing the image
      */
     public void writeImage(BufferedImage img, TranscoderOutput output)
             throws TranscoderException {
@@ -142,7 +142,7 @@ public class PNGTranscoder extends ImageTranscoder {
          * @param transcoder the calling PNGTranscoder
          * @param img the image to write
          * @param output the output where to store the image
-         * @throws TranscoderException if an error occured while storing the image
+         * @throws TranscoderException if an error occurred while storing the image
          */
         void writeImage(PNGTranscoder transcoder, BufferedImage img,
                 TranscoderOutput output) throws TranscoderException;

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/TIFFTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/TIFFTranscoder.java
@@ -41,7 +41,7 @@ public class TIFFTranscoder extends ImageTranscoder {
     /**
      * Constructs a new transcoder that produces tiff images.
      */
-    public TIFFTranscoder() { 
+    public TIFFTranscoder() {
         hints.put(KEY_FORCE_TRANSPARENT_WHITE, Boolean.FALSE);
     }
 
@@ -49,7 +49,7 @@ public class TIFFTranscoder extends ImageTranscoder {
     public UserAgent getUserAgent() {
         return this.userAgent;
     }
-    
+
     /**
      * Creates a new ARGB image with the specified dimension.
      * @param width the image width in pixels
@@ -77,7 +77,7 @@ public class TIFFTranscoder extends ImageTranscoder {
             return null;
         }
     }
-    
+
     /**
      * Writes the specified image to the specified output.
      * @param img the image to write
@@ -113,23 +113,23 @@ public class TIFFTranscoder extends ImageTranscoder {
         }
         if (adapter == null) {
             throw new TranscoderException(
-                    "Could not write TIFF file because no WriteAdapter is availble");
+                    "Could not write TIFF file because no WriteAdapter is available");
         }
         adapter.writeImage(this, img, output);
     }
-    
+
     // --------------------------------------------------------------------
     // TIFF specific interfaces
     // --------------------------------------------------------------------
 
     /**
-     * This interface is used by <code>TIFFTranscoder</code> to write TIFF images 
+     * This interface is used by <code>TIFFTranscoder</code> to write TIFF images
      * through different codecs.
      *
      * @version $Id$
      */
     public interface WriteAdapter {
-        
+
         /**
          * Writes the specified image to the specified output.
          * @param transcoder the calling PNGTranscoder
@@ -137,11 +137,11 @@ public class TIFFTranscoder extends ImageTranscoder {
          * @param output the output where to store the image
          * @throws TranscoderException if an error occured while storing the image
          */
-        void writeImage(TIFFTranscoder transcoder, BufferedImage img, 
+        void writeImage(TIFFTranscoder transcoder, BufferedImage img,
                 TranscoderOutput output) throws TranscoderException;
 
     }
-    
+
 
     // --------------------------------------------------------------------
     // Keys definition
@@ -180,7 +180,7 @@ public class TIFFTranscoder extends ImageTranscoder {
      *       over a white background in a viewer that supports
      *       transparency.</td>
      *   </tr>
-     * </table> 
+     * </table>
      */
     public static final TranscodingHints.Key KEY_FORCE_TRANSPARENT_WHITE
         = ImageTranscoder.KEY_FORCE_TRANSPARENT_WHITE;
@@ -212,5 +212,5 @@ public class TIFFTranscoder extends ImageTranscoder {
      */
     public static final TranscodingHints.Key KEY_COMPRESSION_METHOD
         = new StringKey();
-    
+
 }

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/TIFFTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/image/TIFFTranscoder.java
@@ -82,7 +82,7 @@ public class TIFFTranscoder extends ImageTranscoder {
      * Writes the specified image to the specified output.
      * @param img the image to write
      * @param output the output where to store the image
-     * @throws TranscoderException if an error occured while storing the image
+     * @throws TranscoderException if an error occurred while storing the image
      */
     public void writeImage(BufferedImage img, TranscoderOutput output)
             throws TranscoderException {
@@ -135,7 +135,7 @@ public class TIFFTranscoder extends ImageTranscoder {
          * @param transcoder the calling PNGTranscoder
          * @param img the image to write
          * @param output the output where to store the image
-         * @throws TranscoderException if an error occured while storing the image
+         * @throws TranscoderException if an error occurred while storing the image
          */
         void writeImage(TIFFTranscoder transcoder, BufferedImage img,
                 TranscoderOutput output) throws TranscoderException;

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/print/PrintTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/print/PrintTranscoder.java
@@ -150,7 +150,7 @@ public class PrintTranscoder extends SVGAbstractTranscoder
      * @param document the document to transcode
      * @param uri the uri of the document or null if any
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     protected void transcode(Document document,
                              String uri,

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/SVGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/SVGTranscoder.java
@@ -160,7 +160,7 @@ public class SVGTranscoder extends AbstractTranscoder {
      * Transcodes the specified input in the specified output.
      * @param input the input to transcode
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     public void transcode(TranscoderInput input, TranscoderOutput output)
         throws TranscoderException {

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/SVGTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/svg2svg/SVGTranscoder.java
@@ -38,7 +38,7 @@ import org.apache.batik.transcoder.keys.StringKey;
 import org.w3c.dom.Document;
 
 /**
- * This class is a trancoder from SVG to SVG.
+ * This class is a transcoder from SVG to SVG.
  *
  * @author <a href="mailto:stephane@hillion.org">Stephane Hillion</a>
  * @version $Id$

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/wmf/tosvg/WMFHeaderProperties.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/wmf/tosvg/WMFHeaderProperties.java
@@ -714,7 +714,7 @@ public class WMFHeaderProperties extends AbstractWMFReader {
      *  There will be no resizing if one of the following properties is true :
      *  <ul>
      *  <li>the brush and the pen objects are < 0 (null objects)</li>
-     *  <li>the color of the geometric Shape is white, and no other Shapes has occured</li>
+     *  <li>the color of the geometric Shape is white, and no other Shapes has occurred</li>
      *  </ul>
      */
     private void paint(int brushObject, int penObject, Shape shape) {
@@ -737,7 +737,7 @@ public class WMFHeaderProperties extends AbstractWMFReader {
      *  There will be no resizing if one of the following properties is true :
      *  <ul>
      *  <li>the pen objects is < 0 (null object)</li>
-     *  <li>the color of the geometric Shape is white, and no other Shapes has occured</li>
+     *  <li>the color of the geometric Shape is white, and no other Shapes has occurred</li>
      *  </ul>
      */
     private void paintWithPen(int penObject, Shape shape) {

--- a/batik-transcoder/src/main/java/org/apache/batik/transcoder/wmf/tosvg/WMFTranscoder.java
+++ b/batik-transcoder/src/main/java/org/apache/batik/transcoder/wmf/tosvg/WMFTranscoder.java
@@ -95,7 +95,7 @@ public class WMFTranscoder extends ToSVGAbstractTranscoder {
      * Transcodes the specified input in the specified output.
      * @param input the input to transcode
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     public void transcode(TranscoderInput input, TranscoderOutput output)
         throws TranscoderException {

--- a/batik-util/src/main/java/org/apache/batik/util/AbstractParsedURLProtocolHandler.java
+++ b/batik-util/src/main/java/org/apache/batik/util/AbstractParsedURLProtocolHandler.java
@@ -25,13 +25,13 @@ package org.apache.batik.util;
  * @author <a href="mailto:thomas.deweese@kodak.com">Thomas DeWeese</a>
  * @version $Id$
  */
-public abstract class AbstractParsedURLProtocolHandler 
+public abstract class AbstractParsedURLProtocolHandler
  implements ParsedURLProtocolHandler {
 
     protected String protocol;
 
     /**
-     * Constrcut a ProtocolHandler for <code>protocol</code>
+     * Construct a ProtocolHandler for <code>protocol</code>
      */
     public AbstractParsedURLProtocolHandler(String protocol) {
         this.protocol = protocol;

--- a/batik-util/src/main/java/org/apache/batik/util/PreferenceManager.java
+++ b/batik-util/src/main/java/org/apache/batik/util/PreferenceManager.java
@@ -151,7 +151,7 @@ public class PreferenceManager
      * in the following order: in the directory set by
      * {@link #setPreferenceDirectory} if it exists, in the user
      * home directory and then in the current user directory.
-     * @exception IOException if an error occured when reading the file.
+     * @exception IOException if an error occurred when reading the file.
      * @see #save
      */
     public void load()
@@ -203,7 +203,7 @@ public class PreferenceManager
      * loaded or save it will save it at the same location. In other cases
      * it will save it in the directory set by {@link #setPreferenceDirectory}
      * if has been set and exists, otherwise in the user home directory.
-     * @exception IOException if an error occured when writing the file or
+     * @exception IOException if an error occurred when writing the file or
      * if is impossible to write the file at all available locations.
      * @see #load
      */

--- a/contrib/fonts/gladiator/svg/glb12.svg
+++ b/contrib/fonts/gladiator/svg/glb12.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" standalone="no"?> 
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" > 
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" >
 
 <!--
 
@@ -23,7 +23,7 @@
 <!-- The Gladiator fonts where created and contributed by Bert Bos.            -->
 <!--                                                                           -->
 <!-- @author bert@w3.org                                                       -->
-<!-- @author vhardy@apache.org (convertion to SVG format)                      -->
+<!-- @author vhardy@apache.org (conversion to SVG format)                      -->
 <!-- @version $Id$            -->
 <!-- ========================================================================= -->
 
@@ -751,15 +751,15 @@
 1075Q841 1077 841 1078V1079Q843 1101 846 1120Q780 1110 731 1162Q695 1200 692 1249Q692 1285 719 1331Z" />
 </font>
 </defs>
-<g style="font-family: 
+<g style="font-family:
 Gladiator
-; font-size:18;fill:black"> 
-<text x="20" y="60"> !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;&gt;?</text> 
-<text x="20" y="120">@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_</text> 
-<text x="20" y="180">`abcdefghijklmnopqrstuvwxyz|{}~</text> 
-<text x="20" y="240">&#x80;&#x81;&#x82;&#x83;&#x84;&#x85;&#x86;&#x87;&#x88;&#x89;&#x8a;&#x8b;&#x8c;&#x8d;&#x8e;&#x8f;&#x90;&#x91;&#x92;&#x93;&#x94;&#x95;&#x96;&#x97;&#x98;&#x99;&#x9a;&#x9b;&#x9c;&#x9d;&#x9e;&#x9f;</text> 
-<text x="20" y="300">&#xa0;&#xa1;&#xa2;&#xa3;&#xa4;&#xa5;&#xa6;&#xa7;&#xa8;&#xa9;&#xaa;&#xab;&#xac;&#xad;&#xae;&#xaf;&#xb0;&#xb1;&#xb2;&#xb3;&#xb4;&#xb5;&#xb6;&#xb7;&#xb8;&#xb9;&#xba;&#xbb;&#xbc;&#xbd;&#xbe;&#xbf;</text> 
-<text x="20" y="360">&#xc0;&#xc1;&#xc2;&#xc3;&#xc4;&#xc5;&#xc6;&#xc7;&#xc8;&#xc9;&#xca;&#xcb;&#xcc;&#xcd;&#xce;&#xcf;&#xd0;&#xd1;&#xd2;&#xd3;&#xd4;&#xd5;&#xd6;&#xd7;&#xd8;&#xd9;&#xda;&#xdb;&#xdc;&#xdd;&#xde;&#xdf;</text> 
-<text x="20" y="420">&#xe0;&#xe1;&#xe2;&#xe3;&#xe4;&#xe5;&#xe6;&#xe7;&#xe8;&#xe9;&#xea;&#xeb;&#xec;&#xed;&#xee;&#xef;&#xf0;&#xf1;&#xf2;&#xf3;&#xf4;&#xf5;&#xf6;&#xf7;&#xf8;&#xf9;&#xfa;&#xfb;&#xfc;&#xfd;&#xfe;&#xff;</text> 
+; font-size:18;fill:black">
+<text x="20" y="60"> !&quot;#$%&amp;&apos;()*+,-./0123456789:;&lt;&gt;?</text>
+<text x="20" y="120">@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_</text>
+<text x="20" y="180">`abcdefghijklmnopqrstuvwxyz|{}~</text>
+<text x="20" y="240">&#x80;&#x81;&#x82;&#x83;&#x84;&#x85;&#x86;&#x87;&#x88;&#x89;&#x8a;&#x8b;&#x8c;&#x8d;&#x8e;&#x8f;&#x90;&#x91;&#x92;&#x93;&#x94;&#x95;&#x96;&#x97;&#x98;&#x99;&#x9a;&#x9b;&#x9c;&#x9d;&#x9e;&#x9f;</text>
+<text x="20" y="300">&#xa0;&#xa1;&#xa2;&#xa3;&#xa4;&#xa5;&#xa6;&#xa7;&#xa8;&#xa9;&#xaa;&#xab;&#xac;&#xad;&#xae;&#xaf;&#xb0;&#xb1;&#xb2;&#xb3;&#xb4;&#xb5;&#xb6;&#xb7;&#xb8;&#xb9;&#xba;&#xbb;&#xbc;&#xbd;&#xbe;&#xbf;</text>
+<text x="20" y="360">&#xc0;&#xc1;&#xc2;&#xc3;&#xc4;&#xc5;&#xc6;&#xc7;&#xc8;&#xc9;&#xca;&#xcb;&#xcc;&#xcd;&#xce;&#xcf;&#xd0;&#xd1;&#xd2;&#xd3;&#xd4;&#xd5;&#xd6;&#xd7;&#xd8;&#xd9;&#xda;&#xdb;&#xdc;&#xdd;&#xde;&#xdf;</text>
+<text x="20" y="420">&#xe0;&#xe1;&#xe2;&#xe3;&#xe4;&#xe5;&#xe6;&#xe7;&#xe8;&#xe9;&#xea;&#xeb;&#xec;&#xed;&#xee;&#xef;&#xf0;&#xf1;&#xf2;&#xf3;&#xf4;&#xf5;&#xf6;&#xf7;&#xf8;&#xf9;&#xfa;&#xfb;&#xfc;&#xfd;&#xfe;&#xff;</text>
 </g>
 </svg>

--- a/contrib/tiledTranscoder/TiledImageTranscoder.java
+++ b/contrib/tiledTranscoder/TiledImageTranscoder.java
@@ -48,7 +48,7 @@ public class TiledImageTranscoder extends SVGAbstractTranscoder {
      * @param document the document to transcode
      * @param uri the uri of the document or null if any
      * @param output the ouput where to transcode
-     * @exception TranscoderException if an error occured while transcoding
+     * @exception TranscoderException if an error occurred while transcoding
      */
     protected void transcode(Document document,
                              String uri,

--- a/documentation-sources/conf/cli.xconf
+++ b/documentation-sources/conf/cli.xconf
@@ -98,7 +98,7 @@
        |     <broken-links type="none"/>
        |
        |   Two attributes to this node specify whether a page should
-       |   be generated when an error has occured. 'generate' specifies
+       |   be generated when an error has occurred. 'generate' specifies
        |   whether a page should be generated (default: true) and
        |   extension specifies an extension that should be appended
        |   to the generated page's filename (default: none)

--- a/samples/3D.svg
+++ b/samples/3D.svg
@@ -27,7 +27,7 @@
 <!-- @version $Id$ -->
 <!-- ====================================================================== -->
 
-<svg xmlns="http://www.w3.org/2000/svg" 
+<svg xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
      id="body" width="640" height="480" viewBox="0 0 640 480">
 
@@ -100,7 +100,7 @@
                 }
         }
 
-        // Makes the current object to disapear
+        // Makes the current object to disappear
         function goObject() {
                 if (_focalDistance+_incFocalDistance <= _minFocalDistance) {
                         switchToObject();
@@ -176,7 +176,7 @@
                 setInterval('animate()', 20);
         }
 
-        // switch object 
+        // switch object
         function switchToObject() {
                 _currentObject++;
                 if (_currentObject == _objects.length) {
@@ -221,7 +221,7 @@
                 }
         }
 
-        // Builds the shapes according to the current points 3D 
+        // Builds the shapes according to the current points 3D
         function buildShape(index) {
                 var e = _shapes[index];
                 var face = _faces[index];
@@ -250,8 +250,8 @@
                 if (z == 0) {
                        z = 1;
                 }
-                destPt2d[0] = _focalDistance * x / (800-z) + _xOrigin; 
-                destPt2d[1] = _focalDistance * y / (800-z) + _yOrigin; 
+                destPt2d[0] = _focalDistance * x / (800-z) + _xOrigin;
+                destPt2d[1] = _focalDistance * y / (800-z) + _yOrigin;
         }
 
 
@@ -292,7 +292,7 @@
                 var s1 = Math.sin(alpha);
                 var c2 = Math.cos(beta);
                 var s2 = Math.sin(beta);
-                var c3 = Math.cos(gamma);    
+                var c3 = Math.cos(gamma);
                 var s3 = Math.sin(gamma);
 
                 matrix[0] = c1 * c2;

--- a/test-resources/org/apache/batik/transcoder/image/unitTesting.xml
+++ b/test-resources/org/apache/batik/transcoder/image/unitTesting.xml
@@ -5,9 +5,9 @@
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at
-   
+
         http://www.apache.org/licenses/LICENSE-2.0
-   
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@
 <!-- @author tkormann@ilog.fr                                               -->
 <!-- @version $Id$ -->
 <!-- ====================================================================== -->
-<testSuite id="transcoder.image.unitTesting" 
+<testSuite id="transcoder.image.unitTesting"
            name="org.apache.batik.transcoder.image.ImageTranscoder Unit Testing">
 
 <!-- ================================================================== -->
@@ -497,7 +497,7 @@
   <arg class="java.lang.String" value="Times" />
 </test>
 
-<test id="trancoder.image.hints.defaultFontFamily.TotoTimes">
+<test id="transcoder.image.hints.defaultFontFamily.TotoTimes">
   <arg class="java.lang.String" value="samples/tests/spec/styling/defaultFontFamily.svg" />
   <arg class="java.lang.String" value="test-references/samples/tests/spec/styling/defaultFontFamilyTimes.png" />
   <arg class="java.lang.String" value="toto, Times" />


### PR DESCRIPTION
This PR fixes some typos in code and comments.

First of all, I wanted to fix the "availble" typo in these **error messages visible to end-user**:

> Could not write PNG file because no WriteAdapter is availble